### PR TITLE
Fix romanization-safe lyric translation and improve vocabulary mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Real-time lyric translation extension for [Spicy Lyrics](https://github.com/Spik
   - OpenAI (API key, configurable model)
   - Gemini (API key)
   - Custom LibreTranslate-compatible endpoint (optional API key)
+- Romanization-safe translation: when Spicy Lyrics romanization is enabled, the translator uses original lyric text from Spicy Lyrics data instead of the romanized on-screen text
+- Fallback lyric source lookup from Spicy Lyrics cache, so already-loaded tracks can still translate even when Spicy Lyrics does not call the lyrics API again
 - Smart language detection that skips translation when lyrics are already in the target language
 - Track-aware caching for faster reloads and better offline behavior
 - Translation quality indicator per line
@@ -81,6 +83,7 @@ The extension works in the full lyrics view, the sidebar lyrics view, and pictur
 - Translation Display: Replace or Below each line
 - Translation API: Google, LibreTranslate, DeepL, OpenAI, Gemini, or Custom
 - API credentials per provider (DeepL key, OpenAI key/model, Gemini key, Custom URL/key)
+- Gemini custom model and temperature
 - Auto-Translate on Song Change
 - Show Notifications
 - Show Translation Quality Indicator
@@ -94,16 +97,64 @@ The extension works in the full lyrics view, the sidebar lyrics view, and pictur
 
 - Track cache keeps up to 100 tracks with expiry pruning
 - Line translation cache keeps up to 500 entries with a 7-day expiry
+- Spicy Lyrics lyric cache is read as a fallback source for original lyrics when possible
 - The connection indicator shows server latency and total installed users
 - No personal data is collected
+
+## Romanization and Original Lyrics
+
+Spicy Lyrics can display romanized lyrics for Japanese, Chinese, Korean, Cyrillic, Greek, and other scripts. Translated lyrics should not be generated from that romanized display text because providers often detect it as Latin text and return weak or incorrect translations.
+
+This extension therefore prefers original lyrics in this order:
+
+1. Captured Spicy Lyrics `/query` API response
+2. Spicy Lyrics cache storage for the current Spotify track
+3. This extension's previously cached original source lines
+4. Visible DOM lyrics only when romanization is not enabled
+
+When romanization is enabled and original lyrics cannot be found, the extension stops instead of sending romanized lyrics to the translation provider.
+
+## Cache Repair Actions
+
+If a track shows stale, missing, or wrong source lyrics:
+
+- Right-click the translate button in the Spicy Lyrics controls
+- Open Spicy Lyric Translator settings
+- Use `Clear Spicy Lyrics Cache` to force Spicy Lyrics to fetch source lyrics again
+- Use `Clear All Cached Translations` to remove old translated lines saved by this extension
+- Switch away from the song and back, or restart Spotify after applying changes
+
+These actions are also available from the Spicetify menu.
+
+## Provider Notes
+
+- DeepL uses header-based authentication (`DeepL-Auth-Key`) and supports free/pro API hosts
+- LibreTranslate sends real POST requests using form data and falls back through Spicetify Cosmos when needed
+- Gemini supports custom model names and temperature
+- OpenAI supports a custom model setting
+- Custom endpoints can use generic, LibreTranslate-compatible, or DeepL-compatible request formats
 
 ## Troubleshooting
 
 - No translate button appears: make sure Spicy Lyrics is installed and the lyrics view is open
 - No translations: verify internet access and your selected API; try switching providers
-- Wrong language or stale lines: clear the cache from settings and retry
+- Wrong language or stale lines: clear both Spicy Lyrics cache and translation cache from the right-click settings popup, then reload the song
+- Romanization is enabled but translation does not start: the extension could not find original lyrics, so it refused to send romanized text to the provider; clear Spicy Lyrics cache and reload the track
 - Extension not loading after manual install: re-run `spicetify apply` and restart Spotify
 - Custom API issues: the endpoint must be LibreTranslate-compatible
+
+## Development
+
+Useful commands:
+
+```bash
+npm run build
+npm test
+npm run deploy
+npm run apply
+```
+
+`npm run deploy` builds the extension and copies `dist/spicy-lyric-translater.js` to the Spicetify extensions directory. `npm run apply` refreshes Spicetify so Spotify can load the new build.
 
 [![Discord](https://img.shields.io/badge/Need%20help%3F-Join%20the%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/fXK34DeDW5)
 

--- a/dist/spicy-lyric-translater.js
+++ b/dist/spicy-lyric-translater.js
@@ -189,6 +189,8 @@ var SpicyLyricTranslater = (() => {
     openaiApiKey: storage.getSecret("openai-api-key") || "",
     openaiModel: storage.get("openai-model") || "gpt-4o-mini",
     geminiApiKey: storage.getSecret("gemini-api-key") || "",
+    geminiModel: storage.get("gemini-model") || "gemini-2.0-flash",
+    geminiTemperature: storage.get("gemini-temperature") || "0.3",
     lastTranslatedSongUri: null,
     translatedLyrics: /* @__PURE__ */ new Map(),
     lastViewMode: null,
@@ -1166,6 +1168,8 @@ var SpicyLyricTranslater = (() => {
   var openaiApiKey = "";
   var openaiModel = "gpt-4o-mini";
   var geminiApiKey = "";
+  var geminiModel = "gemini-2.0-flash";
+  var geminiTemperature = 0.3;
   var RATE_LIMIT = {
     minDelayMs: 100,
     maxDelayMs: 2e3,
@@ -1177,6 +1181,7 @@ var SpicyLyricTranslater = (() => {
   var BATCH_MARKER_PREFIX = "[[SLT_BATCH_";
   var BATCH_CHUNK_SIZE = 6;
   var NON_LATIN_SEGMENT_REGEX = /([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Cyrillic}\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Devanagari}\p{Script=Greek}]+)/gu;
+  var SPICETIFY_CORS_PROXY_BASE = "https://cors-proxy.spicetify.app/";
   function normalizeSourceLineForFingerprint(line) {
     return (line || "").replace(/\s+/g, " ").trim().toLowerCase();
   }
@@ -1358,6 +1363,114 @@ var SpicyLyricTranslater = (() => {
     }
     lastApiCallTime = Date.now();
   }
+  function getCosmosAsync() {
+    try {
+      return globalThis.Spicetify?.CosmosAsync || null;
+    } catch {
+      return null;
+    }
+  }
+  function isLikelyCorsOrNetworkError(err) {
+    if (err instanceof TypeError)
+      return true;
+    const message = err instanceof Error ? err.message : String(err || "");
+    return /failed to fetch|networkerror|cors|load failed/i.test(message);
+  }
+  var NonRetryableProviderError = class extends Error {
+    constructor(message, status) {
+      super(message);
+      this.status = status;
+      this.name = "NonRetryableProviderError";
+    }
+  };
+  function isNonRetryableProviderError(err) {
+    if (err instanceof NonRetryableProviderError)
+      return true;
+    const message = err instanceof Error ? err.message : String(err || "");
+    const statusMatch = message.match(/\b(4\d\d)\b/);
+    if (!statusMatch)
+      return false;
+    const status = Number(statusMatch[1]);
+    return status !== 408 && status !== 429;
+  }
+  function createProviderHttpError(providerName, status, errorText) {
+    const message = `${providerName} API error: ${status}${errorText ? ` ${errorText.slice(0, 160)}` : ""}`;
+    if (status >= 400 && status < 500 && status !== 408 && status !== 429) {
+      return new NonRetryableProviderError(message, status);
+    }
+    return new Error(message);
+  }
+  function getSpicetifyCorsProxyUrl(url) {
+    return `${SPICETIFY_CORS_PROXY_BASE}${url}`;
+  }
+  async function postJsonProvider(url, body, headers, providerName, options = {}) {
+    const cosmos = getCosmosAsync();
+    if (options.preferCosmos && cosmos?.post) {
+      return cosmos.post(url, body, headers);
+    }
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body)
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw createProviderHttpError(providerName, response.status, errorText);
+      }
+      return await response.json();
+    } catch (err) {
+      if (cosmos?.post && isLikelyCorsOrNetworkError(err)) {
+        return cosmos.post(url, body, headers);
+      }
+      throw err;
+    }
+  }
+  function buildLibreTranslateForm(text, targetLang) {
+    const params = new URLSearchParams();
+    const values = Array.isArray(text) ? text : [text];
+    values.forEach((value) => params.append("q", value));
+    params.set("source", "auto");
+    params.set("target", targetLang);
+    params.set("format", "text");
+    return params;
+  }
+  function formToJsonObject(params) {
+    const result = {};
+    params.forEach((value, key) => {
+      const existing = result[key];
+      if (existing === void 0) {
+        result[key] = value;
+      } else if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        result[key] = [existing, value];
+      }
+    });
+    return result;
+  }
+  async function postFormProvider(url, params, providerName, options = {}) {
+    const cosmos = getCosmosAsync();
+    if (options.preferCosmos && cosmos?.post) {
+      return cosmos.post(url, formToJsonObject(params), { "Content-Type": "application/json" });
+    }
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        body: params
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw createProviderHttpError(providerName, response.status, errorText);
+      }
+      return await response.json();
+    } catch (err) {
+      if (cosmos?.post && isLikelyCorsOrNetworkError(err)) {
+        return cosmos.post(url, formToJsonObject(params), { "Content-Type": "application/json" });
+      }
+      throw err;
+    }
+  }
   async function retryWithBackoff(fn, maxRetries = RATE_LIMIT.maxRetries, baseDelay = RATE_LIMIT.minDelayMs) {
     let lastError = null;
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -1366,7 +1479,7 @@ var SpicyLyricTranslater = (() => {
         return await fn();
       } catch (error2) {
         lastError = error2;
-        if (error2 instanceof Error && error2.message.includes("40")) {
+        if (isNonRetryableProviderError(error2)) {
           throw error2;
         }
         if (attempt < maxRetries) {
@@ -1400,6 +1513,10 @@ var SpicyLyricTranslater = (() => {
         openaiModel = apiKeys.openaiModel;
       if (apiKeys.geminiApiKey !== void 0)
         geminiApiKey = apiKeys.geminiApiKey;
+      if (apiKeys.geminiModel !== void 0)
+        geminiModel = apiKeys.geminiModel;
+      if (apiKeys.geminiTemperature !== void 0)
+        geminiTemperature = normalizeGeminiTemperature(apiKeys.geminiTemperature);
     }
   }
   var CACHE_EXPIRY = 7 * 24 * 60 * 60 * 1e3;
@@ -1621,22 +1738,12 @@ var SpicyLyricTranslater = (() => {
   }
   async function translateWithLibreTranslate(text, targetLang) {
     const url = "https://libretranslate.de/translate";
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        q: text,
-        source: "auto",
-        target: targetLang,
-        format: "text"
-      })
-    });
-    if (!response.ok) {
-      throw new Error(`LibreTranslate API error: ${response.status}`);
-    }
-    const data = await response.json();
+    const data = await postFormProvider(
+      url,
+      buildLibreTranslateForm(text, targetLang),
+      "LibreTranslate",
+      { preferCosmos: true }
+    );
     return data.translatedText;
   }
   async function translateWithDeepL(text, targetLang) {
@@ -1646,29 +1753,12 @@ var SpicyLyricTranslater = (() => {
     const isFreePlan = deeplApiKey.endsWith(":fx");
     const baseUrl = isFreePlan ? "https://api-free.deepl.com" : "https://api.deepl.com";
     const url = `${baseUrl}/v2/translate`;
-    const deeplLangMap = {
-      "en": "EN-US",
-      "pt": "PT-BR",
-      "zh": "ZH-HANS",
-      "zh-TW": "ZH-HANT"
-    };
-    const deeplTarget = deeplLangMap[targetLang] || targetLang.toUpperCase();
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Authorization": `DeepL-Auth-Key ${deeplApiKey}`,
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        text: [text],
-        target_lang: deeplTarget
-      })
-    });
-    if (!response.ok) {
-      const errorText = await response.text().catch(() => "");
-      throw new Error(`DeepL API error: ${response.status}`);
-    }
-    const data = await response.json();
+    const data = await postJsonProvider(
+      getSpicetifyCorsProxyUrl(url),
+      buildDeepLBody([text], targetLang),
+      getDeepLHeaders(deeplApiKey),
+      "DeepL"
+    );
     if (data.translations && data.translations.length > 0) {
       return {
         translation: data.translations[0].text,
@@ -1717,12 +1807,27 @@ var SpicyLyricTranslater = (() => {
     }
     throw new Error("Invalid response from OpenAI API");
   }
+  function normalizeGeminiModelName(model) {
+    const trimmed = (model || "").trim().replace(/^models\//, "");
+    return trimmed || "gemini-2.0-flash";
+  }
+  function normalizeGeminiTemperature(value) {
+    const parsed = typeof value === "number" ? value : Number.parseFloat(String(value ?? ""));
+    if (!Number.isFinite(parsed)) {
+      return 0.3;
+    }
+    return Math.min(2, Math.max(0, parsed));
+  }
+  function getGeminiGenerateContentUrl(model) {
+    const normalizedModel = normalizeGeminiModelName(model);
+    return `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(normalizedModel)}:generateContent`;
+  }
   async function translateWithGemini(text, targetLang) {
     if (!geminiApiKey) {
       throw new Error("Gemini API key not configured. Set it in Settings.");
     }
     const langName = SUPPORTED_LANGUAGES.find((l) => l.code === targetLang)?.name || targetLang;
-    const response = await fetch("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent", {
+    const response = await fetch(getGeminiGenerateContentUrl(geminiModel), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -1741,7 +1846,7 @@ ${text}`
           }
         ],
         generationConfig: {
-          temperature: 0.3,
+          temperature: geminiTemperature,
           maxOutputTokens: Math.max(text.length * 3, 500)
         }
       })
@@ -1784,6 +1889,18 @@ ${text}`
       "zh-TW": "ZH-HANT"
     };
     return deeplLangMap[targetLang] || targetLang.toUpperCase();
+  }
+  function buildDeepLBody(texts, targetLang) {
+    return {
+      text: texts,
+      target_lang: getDeepLTargetLanguage(targetLang)
+    };
+  }
+  function getDeepLHeaders(apiKey) {
+    return {
+      "Authorization": `DeepL-Auth-Key ${apiKey}`,
+      "Content-Type": "application/json"
+    };
   }
   function getTranslationLanguageName(targetLang) {
     return SUPPORTED_LANGUAGES.find((l) => l.code === targetLang)?.name || targetLang;
@@ -1847,7 +1964,7 @@ ${text}`
           }
         ],
         generationConfig: {
-          temperature: 0.3,
+          temperature: geminiTemperature,
           maxOutputTokens: Math.max(text.length * 3, 500)
         }
       };
@@ -1983,25 +2100,21 @@ ${text}`
       return { translations: [], detectedLang: void 0 };
     }
     if (preferredApi === "deepl" && deeplApiKey || preferredApi === "custom" && customApiFormat === "deepl") {
-      const isFreePlan = deeplApiKey.endsWith(":fx");
+      const selectedDeepLKey = preferredApi === "custom" ? customApiKey : deeplApiKey;
+      const isFreePlan = selectedDeepLKey.endsWith(":fx");
       const baseUrl = isFreePlan ? "https://api-free.deepl.com" : "https://api.deepl.com";
       const url2 = preferredApi === "custom" ? validateCustomApiUrl() : `${baseUrl}/v2/translate`;
-      const headers2 = preferredApi === "custom" ? getCustomApiHeaders("deepl") : {
-        "Authorization": `DeepL-Auth-Key ${deeplApiKey}`,
-        "Content-Type": "application/json"
-      };
-      const response2 = await fetch(url2, {
-        method: "POST",
-        headers: headers2,
-        body: JSON.stringify({
-          text: texts,
-          target_lang: getDeepLTargetLanguage(targetLang)
-        })
-      });
-      if (!response2.ok) {
-        throw new Error(`DeepL batch API error: ${response2.status}`);
-      }
-      const data2 = await response2.json();
+      const data2 = preferredApi === "deepl" ? await postJsonProvider(
+        getSpicetifyCorsProxyUrl(url2),
+        buildDeepLBody(texts, targetLang),
+        getDeepLHeaders(selectedDeepLKey),
+        "DeepL batch"
+      ) : await postJsonProvider(
+        url2,
+        buildDeepLBody(texts, targetLang),
+        getCustomApiHeaders("deepl"),
+        "DeepL batch"
+      );
       if (data2.translations && Array.isArray(data2.translations)) {
         return {
           translations: data2.translations.map((t) => t.text || ""),
@@ -2017,26 +2130,24 @@ ${text}`
     if (!url) {
       throw new Error("Custom API URL not configured");
     }
-    const headers = preferredApi === "custom" ? getCustomApiHeaders(customApiFormat || "generic") : {
-      "Content-Type": "application/json"
-    };
-    const response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
+    const data = preferredApi === "libretranslate" ? await postFormProvider(
+      url,
+      buildLibreTranslateForm(texts.join("\n"), targetLang),
+      "LibreTranslate batch",
+      { preferCosmos: true }
+    ) : await postJsonProvider(
+      url,
+      {
         q: texts,
         text: texts,
         source: "auto",
         target: targetLang,
         target_lang: targetLang,
         format: "text"
-      })
-    });
-    if (!response.ok) {
-      const errorBody = await response.text().catch(() => "");
-      throw new Error(`Batch API error: ${response.status}`);
-    }
-    const data = await response.json();
+      },
+      getCustomApiHeaders(customApiFormat || "generic"),
+      "Batch API"
+    );
     const normalized = normalizeBatchTranslations(data);
     if (normalized) {
       return normalized;
@@ -2055,6 +2166,9 @@ ${text}`
     const markerNonce = `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
     const combinedText = lines.map((line, index) => `${BATCH_MARKER_PREFIX}${markerNonce}_${index}]]${line}`).join("\n");
     return { combinedText, markerNonce };
+  }
+  function hasInternalBatchMarkers(text) {
+    return (text || "").includes(BATCH_MARKER_PREFIX) || /\[\[\s*SLT[\s_-]*BATCH/i.test(text || "");
   }
   function parseMarkedBatchResponse(translatedText, expectedCount, markerNonce) {
     const markerRegex = new RegExp(`\\[\\[SLT_BATCH_${markerNonce}_(\\d+)\\]\\]`, "g");
@@ -2088,14 +2202,29 @@ ${text}`
     return byIndex;
   }
   function normalizeTranslatedLine(text) {
-    return text.replace(/\[\[\s*SLT[\s_-]*BATCH[^\]]*\]\]/gi, "").replace(/\[\[\s*[A-Za-z0-9]+[_\s-]*BATCH[_\s-]*[A-Za-z0-9]*[_\s-]*\d+\s*\]\]/gi, "").replace(/\[\[\s*[A-Za-z0-9_\s-]*\d+\s*\]\]/g, "").replace(/\bSLT[\s_-]*BATCH[\s_-]*[A-Za-z0-9_-]*\b/gi, "").replace(/^\s*[A-Za-z]{2,12}[_\s-]+\d+\s*\]?\]?\s*/g, "").replace(/\r?\n+/g, " ").replace(/\s+/g, " ").trim();
+    return text.replace(/```[a-z0-9_-]*/gi, "").replace(/\[\[\s*SLT[\s_-]*BATCH[^\]]*\]\]/gi, "").replace(/\[\[\s*[A-Za-z0-9]+[_\s-]*BATCH[_\s-]*[A-Za-z0-9]*[_\s-]*\d+\s*\]\]/gi, "").replace(/\[\[\s*[A-Za-z0-9_\s-]*\d+\s*\]\]/g, "").replace(/\bSLT[\s_-]*BATCH[\s_-]*[A-Za-z0-9_-]*\b/gi, "").replace(/^\s*[A-Za-z]{2,12}[_\s-]+\d+\s*\]?\]?\s*/g, "").replace(/\r?\n+/g, " ").replace(/\s+/g, " ").trim();
+  }
+  function foldWrapperLineForComparison(text) {
+    return (text || "").normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().trim();
+  }
+  function isBatchWrapperLine(line) {
+    const folded = foldWrapperLineForComparison(line);
+    if (!folded)
+      return true;
+    if (/^```/.test(folded))
+      return true;
+    return /^(here('|')?s|here is|here are|sure[,!. ]|translation:?|translated lyrics:?|ban dich:?|duoi day|day la)/.test(folded);
+  }
+  function removeBatchWrapperLines(text) {
+    return (text || "").split(/\r?\n/).filter((line) => !isBatchWrapperLine(line)).join("\n");
   }
   function parseBatchTextFallbacks(translatedText, expectedCount) {
-    const separatorSplit = translatedText.split(BATCH_SEPARATOR_REGEX).map((s) => normalizeTranslatedLine(s));
+    const batchText = removeBatchWrapperLines(translatedText);
+    const separatorSplit = batchText.split(BATCH_SEPARATOR_REGEX).map((s) => normalizeTranslatedLine(s));
     if (separatorSplit.length === expectedCount) {
       return separatorSplit;
     }
-    const newlineSplit = translatedText.split(/\r?\n+/).map((s) => normalizeTranslatedLine(s)).filter(Boolean);
+    const newlineSplit = batchText.split(/\r?\n+/).map((s) => normalizeTranslatedLine(s)).filter(Boolean);
     if (newlineSplit.length === expectedCount) {
       return newlineSplit;
     }
@@ -2137,6 +2266,9 @@ ${text}`
           return batchResult;
         }
       } catch (batchArrayError) {
+        if (isNonRetryableProviderError(batchArrayError)) {
+          throw batchArrayError;
+        }
         warn("Source-aligned batch-array translation unavailable, falling back to marker batching:", batchArrayError);
       }
     }
@@ -2270,6 +2402,13 @@ ${text}`
         wasTranslated: true
       };
     } catch (primaryError) {
+      if (isNonRetryableProviderError(primaryError)) {
+        throw primaryError;
+      }
+      if (hasInternalBatchMarkers(text)) {
+        const message = primaryError instanceof Error ? primaryError.message : String(primaryError || "Provider failed");
+        throw new NonRetryableProviderError(message);
+      }
       warn(`Primary API (${preferredApi}) failed, trying fallbacks:`, primaryError);
       for (const fallbackApi of fallbackApis) {
         try {
@@ -2401,6 +2540,9 @@ ${text}`
             detectedLang = batchResult.detectedLang;
           }
         } catch (batchArrayError) {
+          if (isNonRetryableProviderError(batchArrayError)) {
+            throw batchArrayError;
+          }
           warn("Batch-array translation unavailable, falling back to marker batching:", batchArrayError);
         }
       }
@@ -2585,6 +2727,8 @@ ${text}`
   // src/utils/lyricsFetcher.ts
   var SPICY_API_HOST = "api.spicylyrics.org";
   var SPICY_QUERY_PATH = "/query";
+  var SPICY_LYRICS_CACHE_NAME = "SpicyLyrics_LyricsStore";
+  var SPICY_LYRICS_CACHE_VERSION = 12;
   var captureCache = /* @__PURE__ */ new Map();
   var interceptorInstalled = false;
   function isLyricsData(obj) {
@@ -2637,6 +2781,50 @@ ${text}`
       }
     }
   }
+  async function readSpicyLyricsCache(trackId) {
+    try {
+      if (!trackId || typeof caches === "undefined" || typeof caches.open !== "function") {
+        return null;
+      }
+      const cache = await caches.open(SPICY_LYRICS_CACHE_NAME);
+      const response = await cache.match(`/${trackId}`);
+      if (!response || typeof response.json !== "function") {
+        return null;
+      }
+      const item = await response.json();
+      if (isLyricsData(item)) {
+        return item;
+      }
+      if (!item || typeof item !== "object" || item.Value === "NO_LYRICS") {
+        return null;
+      }
+      if (typeof item.CacheVersion === "number" && item.CacheVersion !== SPICY_LYRICS_CACHE_VERSION) {
+        return null;
+      }
+      if (typeof item.ExpiresAt === "number" && item.ExpiresAt < Date.now()) {
+        return null;
+      }
+      const content = item.Content;
+      if (!content || content.Value === "NO_LYRICS") {
+        return null;
+      }
+      return isLyricsData(content) ? content : null;
+    } catch (err) {
+      warn("Failed to read Spicy Lyrics cache:", err);
+      return null;
+    }
+  }
+  async function getStoredLyricsData(trackId) {
+    const captured = captureCache.get(trackId);
+    if (captured)
+      return captured;
+    const cached = await readSpicyLyricsCache(trackId);
+    if (cached) {
+      captureCache.set(trackId, cached);
+      return cached;
+    }
+    return null;
+  }
   function installFetchInterceptor() {
     if (interceptorInstalled)
       return;
@@ -2684,13 +2872,20 @@ ${text}`
   installFetchInterceptor();
   async function waitForCapture(trackId, timeoutMs = 8e3, pollMs = 100) {
     const start = Date.now();
+    let nextStoreCheck = 0;
     while (Date.now() - start < timeoutMs) {
       const cached = captureCache.get(trackId);
       if (cached)
         return cached;
+      if (Date.now() >= nextStoreCheck) {
+        const stored = await getStoredLyricsData(trackId);
+        if (stored)
+          return stored;
+        nextStoreCheck = Date.now() + 500;
+      }
       await new Promise((resolve) => setTimeout(resolve, pollMs));
     }
-    return captureCache.get(trackId) ?? null;
+    return getStoredLyricsData(trackId);
   }
   function getCurrentTrackId() {
     try {
@@ -2825,6 +3020,20 @@ ${text}`
       return language;
     return void 0;
   }
+  function cacheParsedLyrics(trackId, lyrics) {
+    const lineData = extractLinesData(lyrics);
+    if (lineData.length === 0) {
+      return null;
+    }
+    cachedTrackId = trackId;
+    cachedLineData = lineData;
+    cachedLanguage = getLyricsLanguage(lyrics) || null;
+    return {
+      lines: lineData.map((l) => l.text),
+      lineData,
+      language: cachedLanguage || void 0
+    };
+  }
   async function fetchLyricsFromAPI() {
     const trackId = getCurrentTrackId();
     if (!trackId) {
@@ -2838,19 +3047,11 @@ ${text}`
       };
     }
     try {
-      const lyrics = await waitForCapture(trackId);
+      const lyrics = await getStoredLyricsData(trackId) || await waitForCapture(trackId);
       if (!lyrics) {
         return null;
       }
-      const lineData = extractLinesData(lyrics);
-      if (lineData.length === 0) {
-        return null;
-      }
-      cachedTrackId = trackId;
-      cachedLineData = lineData;
-      cachedLanguage = getLyricsLanguage(lyrics) || null;
-      const lines = lineData.map((l) => l.text);
-      return { lines, lineData, language: cachedLanguage || void 0 };
+      return cacheParsedLyrics(trackId, lyrics);
     } catch (err) {
       warn("Failed to capture lyrics from Spicy Lyrics fetch:", err);
       return null;
@@ -2869,22 +3070,11 @@ ${text}`
       };
     }
     try {
-      const lyrics = await waitForCapture(trackId);
+      const lyrics = await getStoredLyricsData(trackId) || await waitForCapture(trackId);
       if (!lyrics) {
         return null;
       }
-      const lineData = extractLinesData(lyrics);
-      if (lineData.length === 0) {
-        return null;
-      }
-      cachedTrackId = trackId;
-      cachedLineData = lineData;
-      cachedLanguage = getLyricsLanguage(lyrics) || null;
-      return {
-        lines: lineData.map((l) => l.text),
-        lineData,
-        language: cachedLanguage || void 0
-      };
+      return cacheParsedLyrics(trackId, lyrics);
     } catch (err) {
       warn("Failed to capture lyrics for track URI:", trackUri, err);
       return null;
@@ -2894,6 +3084,7 @@ ${text}`
     cachedTrackId = null;
     cachedLineData = null;
     cachedLanguage = null;
+    captureCache.clear();
   }
 
   // src/utils/translationOverlay.ts
@@ -6657,19 +6848,26 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       if (btn.classList.contains("active"))
         return true;
     }
+    const keys = [
+      "SpicyLyrics-romanization",
+      "SpicyLyrics:romanization",
+      "romanization"
+    ];
     try {
       const spicetifyStorage = globalThis.Spicetify?.LocalStorage;
       if (spicetifyStorage?.get) {
-        const val = spicetifyStorage.get("SpicyLyrics:romanization");
-        if (val === "true")
-          return true;
-        if (val === "false")
-          return false;
+        for (const key of keys) {
+          const val = spicetifyStorage.get(key);
+          if (val === "true")
+            return true;
+          if (val === "false")
+            return false;
+        }
       }
     } catch (e) {
     }
     try {
-      for (const key of ["SpicyLyrics:romanization", "romanization"]) {
+      for (const key of keys) {
         const val = localStorage.getItem(key);
         if (val === "true")
           return true;
@@ -6922,6 +7120,66 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
     }
     return document.querySelectorAll(".non-existent-selector");
   }
+  function emptyLineData() {
+    return {
+      text: "",
+      startTime: 0,
+      endTime: 0,
+      isInstrumental: false
+    };
+  }
+  function hasOriginalScript(lines) {
+    return Boolean(lines?.some((line) => /[\u3040-\u30FF\u4E00-\u9FFF\u3400-\u4DBF\uAC00-\uD7AF\u1100-\u11FF\u0600-\u06FF\u0590-\u05FF\u0400-\u04FF\u0E00-\u0E7F\u0900-\u097F\u0370-\u03FF]/.test(line || "")));
+  }
+  function resolveTranslationSourceLines(input) {
+    const domLineTexts = [...input.domLineTexts];
+    const cachedOriginalLines = hasOriginalScript(input.cachedSourceLines) ? [...input.cachedSourceLines] : null;
+    let apiVocalTexts = input.apiVocalTexts ? [...input.apiVocalTexts] : cachedOriginalLines;
+    let apiVocalLineData = input.apiVocalLineData ? [...input.apiVocalLineData] : cachedOriginalLines?.map((line) => ({ ...emptyLineData(), text: line })) || null;
+    if (input.romanizationOn) {
+      if (!apiVocalTexts || apiVocalTexts.length === 0) {
+        return {
+          canTranslate: false,
+          reason: "missing-original-lyrics",
+          lineTexts: [],
+          useApiLines: false,
+          apiVocalTexts,
+          apiVocalLineData
+        };
+      }
+      const domCount = domLineTexts.length;
+      if (domCount > 0 && apiVocalTexts.length > domCount) {
+        apiVocalTexts = apiVocalTexts.slice(0, domCount);
+        if (apiVocalLineData)
+          apiVocalLineData = apiVocalLineData.slice(0, domCount);
+      } else if (domCount > 0 && apiVocalTexts.length < domCount) {
+        for (let i = apiVocalTexts.length; i < domCount; i++) {
+          apiVocalTexts.push("");
+          if (apiVocalLineData) {
+            apiVocalLineData.push(emptyLineData());
+          }
+        }
+      }
+      const hasOriginalText = apiVocalTexts.some((text) => text.trim().length > 0);
+      return {
+        canTranslate: hasOriginalText,
+        reason: hasOriginalText ? void 0 : "missing-original-lyrics",
+        lineTexts: hasOriginalText ? apiVocalTexts : [],
+        useApiLines: hasOriginalText,
+        apiVocalTexts,
+        apiVocalLineData
+      };
+    }
+    const useApiLines = Boolean(apiVocalTexts && apiVocalTexts.length === domLineTexts.length);
+    const lineTexts = useApiLines ? apiVocalTexts : domLineTexts;
+    return {
+      canTranslate: lineTexts.some((text) => text.trim().length > 0),
+      lineTexts,
+      useApiLines,
+      apiVocalTexts,
+      apiVocalLineData
+    };
+  }
   function getLyricsFirstLineText() {
     const lines = getLyricsLines();
     if (lines.length > 0) {
@@ -7022,6 +7280,8 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       let apiLineTexts = null;
       let apiLanguage;
       let apiLineData = null;
+      let cachedSourceLines = null;
+      let cachedSourceLanguage;
       try {
         const apiResult = await fetchLyricsFromAPI();
         if (apiResult && apiResult.lines.length > 0) {
@@ -7031,6 +7291,13 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
         }
       } catch (apiErr) {
         warn("SpicyLyrics API fetch failed, falling back to DOM:", apiErr);
+      }
+      if (romanizationOn && currentTrackUri2) {
+        const trackCache = getTrackCache(currentTrackUri2, state.targetLanguage);
+        if (trackCache?.sourceLines && hasOriginalScript(trackCache.sourceLines)) {
+          cachedSourceLines = trackCache.sourceLines;
+          cachedSourceLanguage = trackCache.lang;
+        }
       }
       let apiVocalTexts = null;
       let apiVocalLineData = null;
@@ -7044,7 +7311,7 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
           }
         }
       }
-      let useApiLines = apiVocalTexts && apiVocalTexts.length === lines.length;
+      let useApiLines = Boolean(apiVocalTexts && apiVocalTexts.length === lines.length);
       if (!useApiLines && romanizationOn && apiVocalTexts && apiVocalTexts.length > 0) {
         for (let retryAttempt = 0; retryAttempt < 4; retryAttempt++) {
           await new Promise((resolve) => setTimeout(resolve, 400));
@@ -7058,29 +7325,25 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
             break;
           }
         }
-        if (!useApiLines && apiVocalTexts.length > 0 && lines.length > 0) {
-          useApiLines = true;
-          const domCount = lines.length;
-          if (apiVocalTexts.length > domCount) {
-            apiVocalTexts = apiVocalTexts.slice(0, domCount);
-            if (apiVocalLineData)
-              apiVocalLineData = apiVocalLineData.slice(0, domCount);
-          } else if (apiVocalTexts.length < domCount) {
-            for (let i = apiVocalTexts.length; i < domCount; i++) {
-              apiVocalTexts.push("");
-              if (apiVocalLineData) {
-                apiVocalLineData.push({
-                  text: "",
-                  startTime: 0,
-                  endTime: 0,
-                  isInstrumental: false
-                });
-              }
-            }
-          }
-        }
       }
-      if (!useApiLines && apiVocalTexts && apiVocalTexts.length > 0) {
+      let sourceSelection = resolveTranslationSourceLines({
+        domLineTexts,
+        romanizationOn,
+        apiVocalTexts,
+        apiVocalLineData,
+        cachedSourceLines
+      });
+      if (!sourceSelection.canTranslate) {
+        removeTranslations();
+        if (romanizationOn && state.showNotifications && Spicetify.showNotification) {
+          Spicetify.showNotification("Original lyrics unavailable while romanization is enabled", true);
+        }
+        return;
+      }
+      apiVocalTexts = sourceSelection.apiVocalTexts;
+      apiVocalLineData = sourceSelection.apiVocalLineData;
+      useApiLines = sourceSelection.useApiLines;
+      if (!romanizationOn && !useApiLines && apiVocalTexts && apiVocalTexts.length > 0) {
         for (let retryAttempt = 0; retryAttempt < 8; retryAttempt++) {
           await new Promise((resolve) => setTimeout(resolve, 600));
           lines = getLyricsLines();
@@ -7098,6 +7361,16 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
             break;
           }
         }
+        sourceSelection = resolveTranslationSourceLines({
+          domLineTexts,
+          romanizationOn,
+          apiVocalTexts,
+          apiVocalLineData,
+          cachedSourceLines
+        });
+        apiVocalTexts = sourceSelection.apiVocalTexts;
+        apiVocalLineData = sourceSelection.apiVocalLineData;
+        useApiLines = sourceSelection.useApiLines;
       }
       let matchedTimingData = null;
       if (!useApiLines && apiVocalTexts && apiVocalLineData && apiVocalTexts.length > 0) {
@@ -7126,7 +7399,7 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
           }
         }
       }
-      const lineTexts = useApiLines ? apiVocalTexts : domLineTexts;
+      const lineTexts = sourceSelection.lineTexts;
       if (useApiLines) {
       } else if (apiVocalTexts) {
       }
@@ -7134,7 +7407,7 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       if (nonEmptyTexts.length === 0) {
         return;
       }
-      const detectedLang = apiLanguage || state.detectedLanguage || void 0;
+      const detectedLang = apiLanguage || cachedSourceLanguage || state.detectedLanguage || void 0;
       let skipCheck;
       if (romanizationOn && apiLanguage) {
         const apiLangSame = isSameLanguage(apiLanguage, state.targetLanguage);
@@ -7782,6 +8055,26 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       visibleForApis: ["gemini"]
     },
     {
+      id: "gemini-model",
+      label: "Gemini Model",
+      type: "text",
+      storageKey: "gemini-model",
+      defaultValue: "gemini-2.0-flash",
+      placeholder: "gemini-2.5-flash, gemini-2.0-flash",
+      description: "Model name used in the Gemini generateContent endpoint",
+      visibleForApis: ["gemini"]
+    },
+    {
+      id: "gemini-temperature",
+      label: "Gemini Temperature",
+      type: "text",
+      storageKey: "gemini-temperature",
+      defaultValue: "0.3",
+      placeholder: "0.0 - 2.0",
+      description: "Controls Gemini output randomness",
+      visibleForApis: ["gemini"]
+    },
+    {
       id: "auto-translate",
       label: "Auto-Translate on Song Change",
       type: "toggle",
@@ -7845,7 +8138,9 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       deeplApiKey: state.deeplApiKey,
       openaiApiKey: state.openaiApiKey,
       openaiModel: state.openaiModel,
-      geminiApiKey: state.geminiApiKey
+      geminiApiKey: state.geminiApiKey,
+      geminiModel: state.geminiModel,
+      geminiTemperature: state.geminiTemperature
     });
   }
   function writeSettingValue(field, value) {
@@ -7899,6 +8194,14 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
         state.geminiApiKey = String(value);
         configureTranslationApi();
         break;
+      case "gemini-model":
+        state.geminiModel = String(value);
+        configureTranslationApi();
+        break;
+      case "gemini-temperature":
+        state.geminiTemperature = String(value);
+        configureTranslationApi();
+        break;
       case "auto-translate":
         state.autoTranslate = Boolean(value);
         break;
@@ -7920,6 +8223,57 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
 
   // src/utils/settings.ts
   var SETTINGS_ID = "spicy-lyric-translator-settings";
+  var SPICY_LYRICS_CACHE_NAME2 = "SpicyLyrics_LyricsStore";
+  function showActionNotification(message, isError = false) {
+    if (state.showNotifications && Spicetify.showNotification) {
+      Spicetify.showNotification(message, isError);
+    }
+  }
+  function clearAllCachedTranslations() {
+    clearTranslationCache();
+    showActionNotification("All cached translations deleted!");
+  }
+  async function clearSpicyLyricsCachedLyrics() {
+    try {
+      clearLyricsCache();
+      if (typeof caches !== "undefined" && typeof caches.delete === "function") {
+        await caches.delete(SPICY_LYRICS_CACHE_NAME2);
+      }
+      showActionNotification("Spicy Lyrics cached lyrics deleted!");
+    } catch (e) {
+      showActionNotification("Failed to clear Spicy Lyrics cached lyrics", true);
+    }
+  }
+  function renderModalCacheActionsMarkup() {
+    return `
+            <button class="slt-button secondary" id="slt-clear-spicy-lyrics-cache" type="button">Clear Spicy Lyrics Cache</button>
+            <button class="slt-button danger" id="slt-clear-translation-cache" type="button">Clear All Cached Translations</button>`;
+  }
+  function bindModalCacheActions(container) {
+    const spicyLyricsCacheButton = container.querySelector("#slt-clear-spicy-lyrics-cache");
+    const translationCacheButton = container.querySelector("#slt-clear-translation-cache");
+    spicyLyricsCacheButton?.addEventListener("click", async () => {
+      const previousText = spicyLyricsCacheButton.textContent || "Clear Spicy Lyrics Cache";
+      spicyLyricsCacheButton.disabled = true;
+      spicyLyricsCacheButton.textContent = "Clearing...";
+      await clearSpicyLyricsCachedLyrics();
+      spicyLyricsCacheButton.textContent = "Cleared";
+      setTimeout(() => {
+        spicyLyricsCacheButton.disabled = false;
+        spicyLyricsCacheButton.textContent = previousText;
+      }, 1200);
+    });
+    translationCacheButton?.addEventListener("click", () => {
+      const previousText = translationCacheButton.textContent || "Clear All Cached Translations";
+      translationCacheButton.disabled = true;
+      clearAllCachedTranslations();
+      translationCacheButton.textContent = "Cleared";
+      setTimeout(() => {
+        translationCacheButton.disabled = false;
+        translationCacheButton.textContent = previousText;
+      }, 1200);
+    });
+  }
   function createNativeToggle(id, label, checked, onChange) {
     const row = document.createElement("div");
     row.className = "x-settings-row";
@@ -8067,13 +8421,7 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       "slt-settings.clear-cache",
       "Clear All Cached Translations",
       "Clear Cache",
-      () => {
-        clearAllTrackCache();
-        clearTranslationCache();
-        if (state.showNotifications && Spicetify.showNotification) {
-          Spicetify.showNotification("All cached translations deleted!");
-        }
-      }
+      clearAllCachedTranslations
     ));
     sectionContent.appendChild(createNativeButton(
       "slt-settings.view-changelog",
@@ -8417,6 +8765,20 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
                 background: var(--spice-card);
                 border: 1px solid var(--spice-button-disabled);
             }
+            .slt-button.danger {
+                background: rgba(255, 80, 80, 0.18);
+                border: 1px solid rgba(255, 80, 80, 0.35);
+                color: #ff7373;
+            }
+            .slt-button.danger:hover {
+                background: rgba(255, 80, 80, 0.3);
+                color: #fff;
+            }
+            .slt-button:disabled {
+                cursor: default;
+                opacity: 0.65;
+                transform: none;
+            }
             .slt-description {
                 display: block;
                 font-size: 12px;
@@ -8436,6 +8798,12 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
             .slt-modal-actions {
                 border-top: 1px solid rgba(255, 255, 255, 0.08);
                 margin-top: 4px;
+            }
+            .slt-modal-cache-actions {
+                display: flex;
+                gap: 8px;
+                flex-wrap: wrap;
+                justify-content: flex-end;
             }
             .slt-modal-footer {
                 color: var(--spice-subtext);
@@ -8474,6 +8842,9 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
 
         <div class="slt-modal-actions">
             <button class="slt-button secondary" id="slt-view-cache">View Translation Cache</button>
+            <div class="slt-modal-cache-actions">
+                ${renderModalCacheActionsMarkup()}
+            </div>
         </div>
         
         <div class="slt-modal-footer">
@@ -8496,6 +8867,7 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
     `;
     setTimeout(() => {
       bindModalSettingsFields(container);
+      bindModalCacheActions(container);
       const viewCacheButton = container.querySelector("#slt-view-cache");
       const viewChangelogPopupButton = container.querySelector("#slt-view-changelog-popup");
       const checkUpdatesButton = container.querySelector("#slt-check-updates");
@@ -9209,8 +9581,7 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       });
       const deleteAllBtn = container.querySelector("#slt-delete-all-cache");
       deleteAllBtn?.addEventListener("click", () => {
-        clearAllTrackCache();
-        clearTranslationCache();
+        clearAllCachedTranslations();
         const tracksEl = container.querySelector("#slt-stat-tracks");
         const linesEl = container.querySelector("#slt-stat-lines");
         const sizeEl = container.querySelector("#slt-stat-size");
@@ -9226,9 +9597,6 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
         const actionsDiv = container.querySelector(".slt-cache-actions");
         if (actionsDiv)
           actionsDiv.remove();
-        if (state.showNotifications && Spicetify.showNotification) {
-          Spicetify.showNotification("All cached translations deleted!");
-        }
       });
     }, 0);
     return container;
@@ -9260,11 +9628,28 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       const registerMenuItem = () => {
         if (Spicetify.Menu) {
           try {
-            new Spicetify.Menu.Item(
-              "Spicy Lyric Translator",
-              false,
-              openSettingsModal
-            ).register();
+            [
+              {
+                label: "Spicy Lyric Translator Settings",
+                callback: openSettingsModal
+              },
+              {
+                label: "Clear Spicy Lyrics Cache",
+                callback: () => {
+                  void clearSpicyLyricsCachedLyrics();
+                }
+              },
+              {
+                label: "Clear SLT Translation Cache",
+                callback: clearAllCachedTranslations
+              }
+            ].forEach((item) => {
+              new Spicetify.Menu.Item(
+                item.label,
+                false,
+                item.callback
+              ).register();
+            });
             return true;
           } catch (e) {
           }
@@ -9686,7 +10071,9 @@ body.SpicySidebarLyrics__Active .slt-qi-dot {
       deeplApiKey: state.deeplApiKey,
       openaiApiKey: state.openaiApiKey,
       openaiModel: state.openaiModel,
-      geminiApiKey: state.geminiApiKey
+      geminiApiKey: state.geminiApiKey,
+      geminiModel: state.geminiModel,
+      geminiTemperature: state.geminiTemperature
     });
     injectStyles();
     initConnectionIndicator();

--- a/dist/spicy-lyric-translater.js
+++ b/dist/spicy-lyric-translater.js
@@ -3339,7 +3339,7 @@ ${text}`
         replaceEl.classList.add("slt-replace-instrumental");
       } else {
         const vocabEnabled = storage.get("vocabulary-mode") === "true";
-        const pairBelowText = romanizationMap.get(index) || originalTextMap.get(index) || originalText;
+        const pairBelowText = originalTextMap.get(index) || romanizationMap.get(index) || originalText;
         if (vocabEnabled) {
           replaceEl.classList.add("slt-vocab-line");
           appendVocabularyPairs(doc, replaceEl, pairBelowText, translation, line, "slt-replace-word");
@@ -3415,23 +3415,232 @@ ${text}`
       container.appendChild(span);
     });
   }
+  var JAPANESE_TEXT_REGEX = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF]/u;
+  var JAPANESE_FINAL_PARTICLES = ["\u304B\u306A", "\u3088\u306D", "\u3060\u3088", "\u3060\u306D", "\u306D", "\u306A", "\u3088", "\u304B", "\u3055"];
+  var JAPANESE_STATE_PREFIXES = [
+    "\u3053\u306E\u307E\u307E",
+    "\u305D\u306E\u307E\u307E",
+    "\u3042\u306E\u307E\u307E",
+    "\u3053\u3093\u306A",
+    "\u305D\u3093\u306A",
+    "\u3042\u3093\u306A",
+    "\u3053\u3053",
+    "\u305D\u3053",
+    "\u3042\u305D\u3053",
+    "\u3053\u308C",
+    "\u305D\u308C",
+    "\u3042\u308C"
+  ];
+  function normalizeVocabularyToken(text) {
+    return (text || "").normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().replace(/[^\p{L}\p{N}?]+/gu, "").trim();
+  }
+  function splitTranslatedWords(text) {
+    return (text || "").trim().split(/\s+/).filter(Boolean);
+  }
+  function splitJapaneseChunk(chunk) {
+    let rest = chunk.trim();
+    const parts = [];
+    let finalParticle = "";
+    const finalMatch = [...JAPANESE_FINAL_PARTICLES].sort((a, b) => b.length - a.length).find((particle) => rest.endsWith(particle) && rest.length > particle.length);
+    if (finalMatch) {
+      finalParticle = finalMatch;
+      rest = rest.slice(0, -finalMatch.length);
+    }
+    const prefix = [...JAPANESE_STATE_PREFIXES].sort((a, b) => b.length - a.length).find((candidate) => rest.startsWith(candidate) && rest.length > candidate.length);
+    if (prefix) {
+      parts.push(prefix);
+      rest = rest.slice(prefix.length);
+    }
+    if (rest.trim()) {
+      parts.push(rest.trim());
+    }
+    if (finalParticle) {
+      parts.push(finalParticle);
+    }
+    return parts.length > 0 ? parts : [chunk];
+  }
+  function segmentVocabularySourceText(text) {
+    const chunks = (text || "").trim().split(/\s+/).filter(Boolean);
+    if (chunks.length === 0)
+      return [];
+    const segments = [];
+    for (const chunk of chunks) {
+      if (JAPANESE_TEXT_REGEX.test(chunk)) {
+        segments.push(...splitJapaneseChunk(chunk));
+      } else {
+        segments.push(chunk);
+      }
+    }
+    return segments.filter(Boolean);
+  }
+  function classifyJapaneseSourceUnit(text) {
+    if (JAPANESE_STATE_PREFIXES.some((prefix) => text.startsWith(prefix)))
+      return "state";
+    if (JAPANESE_FINAL_PARTICLES.includes(text))
+      return "final";
+    return "content";
+  }
+  function translatedPhraseRange(translatedWords, phrases, usedIndexes, preferEnd = false) {
+    const normalizedWords = translatedWords.map(normalizeVocabularyToken);
+    const normalizedPhrases = phrases.map((phrase) => phrase.map(normalizeVocabularyToken).filter(Boolean)).filter((phrase) => phrase.length > 0).sort((a, b) => b.length - a.length);
+    for (const phrase of normalizedPhrases) {
+      const starts = normalizedWords.map((_, index) => index).filter((index) => index + phrase.length <= normalizedWords.length);
+      if (preferEnd)
+        starts.reverse();
+      for (const start of starts) {
+        const end = start + phrase.length;
+        let matches = true;
+        for (let i = start; i < end; i++) {
+          if (usedIndexes.has(i) || normalizedWords[i] !== phrase[i - start]) {
+            matches = false;
+            break;
+          }
+        }
+        if (matches)
+          return { start, end };
+      }
+    }
+    return null;
+  }
+  function contiguousUnusedRanges(totalWords, usedIndexes) {
+    const ranges = [];
+    let start = -1;
+    for (let i = 0; i < totalWords; i++) {
+      if (!usedIndexes.has(i)) {
+        if (start === -1)
+          start = i;
+      } else if (start !== -1) {
+        ranges.push({ start, end: i });
+        start = -1;
+      }
+    }
+    if (start !== -1)
+      ranges.push({ start, end: totalWords });
+    return ranges;
+  }
+  function phraseFromRange(words, range) {
+    return words.slice(range.start, range.end).join(" ").trim();
+  }
+  function alignJapaneseVocabularyPairs(sourceUnits, translatedWords, originalText, translatedText) {
+    const usedTranslatedIndexes = /* @__PURE__ */ new Set();
+    const assignments = /* @__PURE__ */ new Map();
+    let semanticMatches = 0;
+    sourceUnits.forEach((unit, sourceIndex) => {
+      const kind = classifyJapaneseSourceUnit(unit);
+      const range = kind === "state" ? translatedPhraseRange(translatedWords, [
+        ["the", "nay"],
+        ["nhu", "vay"],
+        ["nhu", "the"],
+        ["vay"],
+        ["this", "way"],
+        ["like", "this"],
+        ["as", "it", "is"],
+        ["as", "is"]
+      ], usedTranslatedIndexes) : kind === "final" ? translatedPhraseRange(translatedWords, [
+        ["thoi"],
+        ["nhe"],
+        ["nhi"],
+        ["day"],
+        ["ha"],
+        ["sao"],
+        ["?"]
+      ], usedTranslatedIndexes, true) : null;
+      if (!range)
+        return;
+      for (let i = range.start; i < range.end; i++)
+        usedTranslatedIndexes.add(i);
+      semanticMatches++;
+      assignments.set(sourceIndex, {
+        original: unit,
+        translated: phraseFromRange(translatedWords, range),
+        confidence: "high",
+        sourceIndex,
+        translatedStart: range.start
+      });
+    });
+    if (semanticMatches === 0) {
+      return [{
+        original: originalText.trim(),
+        translated: translatedText.trim(),
+        confidence: "low",
+        sourceIndex: 0,
+        translatedStart: 0
+      }];
+    }
+    const unassignedSourceIndexes = sourceUnits.map((_, index) => index).filter((index) => !assignments.has(index));
+    const remainingRanges = contiguousUnusedRanges(translatedWords.length, usedTranslatedIndexes).filter((range) => range.end > range.start);
+    if (unassignedSourceIndexes.length === 1 && remainingRanges.length > 0) {
+      const sourceIndex = unassignedSourceIndexes[0];
+      const first = remainingRanges[0];
+      const last = remainingRanges[remainingRanges.length - 1];
+      assignments.set(sourceIndex, {
+        original: sourceUnits[sourceIndex],
+        translated: phraseFromRange(translatedWords, { start: first.start, end: last.end }),
+        confidence: "medium",
+        sourceIndex,
+        translatedStart: first.start
+      });
+    } else if (unassignedSourceIndexes.length > 1 && remainingRanges.length > 0) {
+      const remainingText = remainingRanges.map((range) => phraseFromRange(translatedWords, range)).join(" ").trim();
+      const translatedBuckets = distributeWords(splitTranslatedWords(remainingText), unassignedSourceIndexes.length);
+      unassignedSourceIndexes.forEach((sourceIndex, bucketIndex) => {
+        if (!translatedBuckets[bucketIndex])
+          return;
+        assignments.set(sourceIndex, {
+          original: sourceUnits[sourceIndex],
+          translated: translatedBuckets[bucketIndex],
+          confidence: "low",
+          sourceIndex,
+          translatedStart: remainingRanges[0].start + bucketIndex
+        });
+      });
+    }
+    const pairs = Array.from(assignments.values()).filter((pair) => pair.original.trim() && pair.translated.trim()).sort((a, b) => a.translatedStart - b.translatedStart || a.sourceIndex - b.sourceIndex);
+    return pairs.length > 0 ? pairs : [{
+      original: originalText.trim(),
+      translated: translatedText.trim(),
+      confidence: "low",
+      sourceIndex: 0,
+      translatedStart: 0
+    }];
+  }
+  function buildVocabularyPairs(originalText, translatedText) {
+    const original = (originalText || "").trim();
+    const translated = (translatedText || "").trim();
+    const sourceUnits = segmentVocabularySourceText(original);
+    const translatedWords = splitTranslatedWords(translated);
+    if (sourceUnits.length === 0 || translatedWords.length === 0) {
+      return [];
+    }
+    if (JAPANESE_TEXT_REGEX.test(original)) {
+      return alignJapaneseVocabularyPairs(sourceUnits, translatedWords, original, translated);
+    }
+    const pairCount = Math.min(sourceUnits.length, translatedWords.length);
+    const originalChunks = distributeWords(sourceUnits, pairCount);
+    const translatedChunks = distributeWords(translatedWords, pairCount);
+    return originalChunks.map((chunk, index) => ({
+      original: chunk,
+      translated: translatedChunks[index],
+      confidence: "medium",
+      sourceIndex: index,
+      translatedStart: index
+    }));
+  }
   function appendVocabularyPairs(doc, container, originalText, translatedText, originalLine, wordClassName) {
-    const origWords = originalText.trim().split(/\s+/).filter(Boolean);
-    const transWords = translatedText.trim().split(/\s+/).filter(Boolean);
-    if (origWords.length === 0 || transWords.length === 0) {
+    const pairs = buildVocabularyPairs(originalText, translatedText);
+    if (pairs.length === 0) {
       container.textContent = translatedText;
       return;
     }
     const originalWordUnits = getWordUnits(originalLine);
-    const pairCount = Math.min(origWords.length, transWords.length);
-    const origChunks = distributeWords(origWords, pairCount);
-    const transChunks = distributeWords(transWords, pairCount);
-    const transRatio = transWords.length / Math.max(originalWordUnits.length, 1);
     let globalWordIndex = 0;
-    for (let i = 0; i < pairCount; i++) {
+    const origChunks = pairs.map((pair) => pair.original);
+    const transChunks = pairs.map((pair) => pair.translated);
+    for (const [i, vocabPair] of pairs.entries()) {
       const pair = doc.createElement("span");
       pair.className = "slt-vocab-pair";
-      const chunkWords = transChunks[i].split(/\s+/).filter(Boolean);
+      pair.dataset.confidence = vocabPair.confidence;
+      const chunkWords = splitTranslatedWords(vocabPair.translated);
       const transSpan = doc.createElement("span");
       transSpan.className = `slt-vocab-translated ${wordClassName}`;
       if (wordClassName === "slt-sync-word") {
@@ -3439,15 +3648,15 @@ ${text}`
       } else {
         transSpan.classList.add("word-notsng");
       }
-      const mappedOriginalIndex = originalWordUnits.length > 0 ? Math.min(Math.floor(globalWordIndex / Math.max(transRatio, 0.01)), originalWordUnits.length - 1) : globalWordIndex;
+      const mappedOriginalIndex = originalWordUnits.length > 0 ? Math.min(vocabPair.sourceIndex, originalWordUnits.length - 1) : vocabPair.sourceIndex;
       transSpan.dataset.originalIndex = Math.max(0, mappedOriginalIndex).toString();
       transSpan.dataset.wordIndex = globalWordIndex.toString();
-      transSpan.textContent = transChunks[i];
+      transSpan.textContent = vocabPair.translated;
       pair.appendChild(transSpan);
       globalWordIndex += chunkWords.length;
       const origSpan = doc.createElement("span");
       origSpan.className = "slt-vocab-original";
-      origSpan.textContent = origChunks[i];
+      origSpan.textContent = vocabPair.original;
       pair.appendChild(origSpan);
       pair.title = `${origChunks[i]}  \u2192  ${transChunks[i]}`;
       container.appendChild(pair);
@@ -3634,7 +3843,7 @@ ${text}`
           translationEl.dataset.forLine = index.toString();
           translationEl.dataset.lineIndex = index.toString();
           const isVocabMode = storage.get("vocabulary-mode") === "true";
-          const pairBelowText = romanizationMap.get(index) || originalTextMap.get(index) || originalText;
+          const pairBelowText = originalTextMap.get(index) || romanizationMap.get(index) || originalText;
           if (isBreak) {
             translationEl.textContent = "\u2022 \u2022 \u2022";
             translationEl.classList.add("slt-music-break");

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "node build.js",
     "build:watch": "node build.js --watch",
+    "test": "node tests/run-tests.mjs",
     "deploy": "npm run build && copy dist\\spicy-lyric-translater.js \"%APPDATA%\\spicetify\\Extensions\\\"",
     "apply": "spicetify apply",
     "release": "npm run build && copy dist\\spicy-lyric-translater.js builds\\spicy-lyric-translater.js"

--- a/src/types/spicetify.d.ts
+++ b/src/types/spicetify.d.ts
@@ -88,7 +88,7 @@ declare const Spicetify: {
     };
     CosmosAsync: {
         get: (url: string, body?: any) => Promise<any>;
-        post: (url: string, body?: any) => Promise<any>;
+        post: (url: string, body?: any, headers?: Record<string, string>) => Promise<any>;
         put: (url: string, body?: any) => Promise<any>;
         del: (url: string, body?: any) => Promise<any>;
     };

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -2,7 +2,7 @@ import { state, TranslationQualityMeta } from './state';
 import { Icons } from './icons';
 import { storage } from './storage';
 import { translateLyrics, isOffline, getCacheStats } from './translator';
-import { getCurrentTrackUri } from './trackCache';
+import { getCurrentTrackUri, getTrackCache } from './trackCache';
 import {
     enableOverlay,
     disableOverlay,
@@ -88,17 +88,25 @@ export function isRomanizationActive(): boolean {
         if (btn.classList.contains('active')) return true;
     }
 
+    const keys = [
+        'SpicyLyrics-romanization',
+        'SpicyLyrics:romanization',
+        'romanization'
+    ];
+
     try {
         const spicetifyStorage = (globalThis as any).Spicetify?.LocalStorage;
         if (spicetifyStorage?.get) {
-            const val = spicetifyStorage.get('SpicyLyrics:romanization');
-            if (val === 'true') return true;
-            if (val === 'false') return false;
+            for (const key of keys) {
+                const val = spicetifyStorage.get(key);
+                if (val === 'true') return true;
+                if (val === 'false') return false;
+            }
         }
     } catch (e) {}
 
     try {
-        for (const key of ['SpicyLyrics:romanization', 'romanization']) {
+        for (const key of keys) {
             const val = localStorage.getItem(key);
             if (val === 'true') return true;
             if (val === 'false') return false;
@@ -406,6 +414,93 @@ function getLyricsLines(): NodeListOf<Element> {
     return document.querySelectorAll('.non-existent-selector');
 }
 
+type MissingOriginalReason = 'missing-original-lyrics';
+
+interface TranslationSourceSelectionInput {
+    domLineTexts: string[];
+    romanizationOn: boolean;
+    apiVocalTexts: string[] | null;
+    apiVocalLineData: LyricLineData[] | null;
+    cachedSourceLines?: string[] | null;
+}
+
+interface TranslationSourceSelection {
+    canTranslate: boolean;
+    reason?: MissingOriginalReason;
+    lineTexts: string[];
+    useApiLines: boolean;
+    apiVocalTexts: string[] | null;
+    apiVocalLineData: LyricLineData[] | null;
+}
+
+function emptyLineData(): LyricLineData {
+    return {
+        text: '',
+        startTime: 0,
+        endTime: 0,
+        isInstrumental: false,
+    };
+}
+
+function hasOriginalScript(lines: string[] | null | undefined): boolean {
+    return Boolean(lines?.some(line => /[\u3040-\u30FF\u4E00-\u9FFF\u3400-\u4DBF\uAC00-\uD7AF\u1100-\u11FF\u0600-\u06FF\u0590-\u05FF\u0400-\u04FF\u0E00-\u0E7F\u0900-\u097F\u0370-\u03FF]/.test(line || '')));
+}
+
+export function resolveTranslationSourceLines(input: TranslationSourceSelectionInput): TranslationSourceSelection {
+    const domLineTexts = [...input.domLineTexts];
+    const cachedOriginalLines = hasOriginalScript(input.cachedSourceLines) ? [...input.cachedSourceLines!] : null;
+    let apiVocalTexts = input.apiVocalTexts ? [...input.apiVocalTexts] : cachedOriginalLines;
+    let apiVocalLineData = input.apiVocalLineData
+        ? [...input.apiVocalLineData]
+        : cachedOriginalLines?.map(line => ({ ...emptyLineData(), text: line })) || null;
+
+    if (input.romanizationOn) {
+        if (!apiVocalTexts || apiVocalTexts.length === 0) {
+            return {
+                canTranslate: false,
+                reason: 'missing-original-lyrics',
+                lineTexts: [],
+                useApiLines: false,
+                apiVocalTexts,
+                apiVocalLineData
+            };
+        }
+
+        const domCount = domLineTexts.length;
+        if (domCount > 0 && apiVocalTexts.length > domCount) {
+            apiVocalTexts = apiVocalTexts.slice(0, domCount);
+            if (apiVocalLineData) apiVocalLineData = apiVocalLineData.slice(0, domCount);
+        } else if (domCount > 0 && apiVocalTexts.length < domCount) {
+            for (let i = apiVocalTexts.length; i < domCount; i++) {
+                apiVocalTexts.push('');
+                if (apiVocalLineData) {
+                    apiVocalLineData.push(emptyLineData());
+                }
+            }
+        }
+
+        const hasOriginalText = apiVocalTexts.some(text => text.trim().length > 0);
+        return {
+            canTranslate: hasOriginalText,
+            reason: hasOriginalText ? undefined : 'missing-original-lyrics',
+            lineTexts: hasOriginalText ? apiVocalTexts : [],
+            useApiLines: hasOriginalText,
+            apiVocalTexts,
+            apiVocalLineData
+        };
+    }
+
+    const useApiLines = Boolean(apiVocalTexts && apiVocalTexts.length === domLineTexts.length);
+    const lineTexts = useApiLines ? apiVocalTexts! : domLineTexts;
+    return {
+        canTranslate: lineTexts.some(text => text.trim().length > 0),
+        lineTexts,
+        useApiLines,
+        apiVocalTexts,
+        apiVocalLineData
+    };
+}
+
 export function getLyricsFirstLineText(): string | null {
     const lines = getLyricsLines();
     if (lines.length > 0) {
@@ -520,6 +615,8 @@ export async function translateCurrentLyrics(): Promise<void> {
         let apiLineTexts: string[] | null = null;
         let apiLanguage: string | undefined;
         let apiLineData: LyricLineData[] | null = null;
+        let cachedSourceLines: string[] | null = null;
+        let cachedSourceLanguage: string | undefined;
         try {
             const apiResult = await fetchLyricsFromAPI();
             if (apiResult && apiResult.lines.length > 0) {
@@ -529,6 +626,14 @@ export async function translateCurrentLyrics(): Promise<void> {
             }
         } catch (apiErr) {
             warn('SpicyLyrics API fetch failed, falling back to DOM:', apiErr);
+        }
+
+        if (romanizationOn && currentTrackUri) {
+            const trackCache = getTrackCache(currentTrackUri, state.targetLanguage);
+            if (trackCache?.sourceLines && hasOriginalScript(trackCache.sourceLines)) {
+                cachedSourceLines = trackCache.sourceLines;
+                cachedSourceLanguage = trackCache.lang;
+            }
         }
         
         let apiVocalTexts: string[] | null = null;
@@ -544,7 +649,7 @@ export async function translateCurrentLyrics(): Promise<void> {
             }
         }
         
-        let useApiLines = apiVocalTexts && apiVocalTexts.length === lines.length;
+        let useApiLines = Boolean(apiVocalTexts && apiVocalTexts.length === lines.length);
         
         if (!useApiLines && romanizationOn && apiVocalTexts && apiVocalTexts.length > 0) {
             for (let retryAttempt = 0; retryAttempt < 4; retryAttempt++) {
@@ -561,33 +666,29 @@ export async function translateCurrentLyrics(): Promise<void> {
                 }
             }
             
-            if (!useApiLines && apiVocalTexts.length > 0 && lines.length > 0) {
-                useApiLines = true;
-                const domCount = lines.length;
-                if (apiVocalTexts.length > domCount) {
-                    apiVocalTexts = apiVocalTexts.slice(0, domCount);
-                    if (apiVocalLineData) apiVocalLineData = apiVocalLineData.slice(0, domCount);
-                } else if (apiVocalTexts.length < domCount) {
-                    // Pad with empty sentinels for excess DOM lines the API doesn't cover.
-                    // Never feed romanized DOM text to the translator — Google auto-detects
-                    // romaji as English and echoes it back unchanged, which then passes
-                    // through applyTranslations and renders as a bogus "translation".
-                    for (let i = apiVocalTexts.length; i < domCount; i++) {
-                        apiVocalTexts.push('');
-                        if (apiVocalLineData) {
-                            apiVocalLineData.push({
-                                text: '',
-                                startTime: 0,
-                                endTime: 0,
-                                isInstrumental: false,
-                            });
-                        }
-                    }
-                }
-            }
         }
 
-        if (!useApiLines && apiVocalTexts && apiVocalTexts.length > 0) {
+        let sourceSelection = resolveTranslationSourceLines({
+            domLineTexts,
+            romanizationOn,
+            apiVocalTexts,
+            apiVocalLineData,
+            cachedSourceLines
+        });
+
+        if (!sourceSelection.canTranslate) {
+            removeTranslations();
+            if (romanizationOn && state.showNotifications && Spicetify.showNotification) {
+                Spicetify.showNotification('Original lyrics unavailable while romanization is enabled', true);
+            }
+            return;
+        }
+
+        apiVocalTexts = sourceSelection.apiVocalTexts;
+        apiVocalLineData = sourceSelection.apiVocalLineData;
+        useApiLines = sourceSelection.useApiLines;
+
+        if (!romanizationOn && !useApiLines && apiVocalTexts && apiVocalTexts.length > 0) {
             for (let retryAttempt = 0; retryAttempt < 8; retryAttempt++) {
                 await new Promise(resolve => setTimeout(resolve, 600));
                 lines = getLyricsLines();
@@ -607,6 +708,17 @@ export async function translateCurrentLyrics(): Promise<void> {
                     break;
                 }
             }
+
+            sourceSelection = resolveTranslationSourceLines({
+                domLineTexts,
+                romanizationOn,
+                apiVocalTexts,
+                apiVocalLineData,
+                cachedSourceLines
+            });
+            apiVocalTexts = sourceSelection.apiVocalTexts;
+            apiVocalLineData = sourceSelection.apiVocalLineData;
+            useApiLines = sourceSelection.useApiLines;
         }
         
         let matchedTimingData: LyricLineData[] | null = null;
@@ -638,7 +750,7 @@ export async function translateCurrentLyrics(): Promise<void> {
             }
         }
         
-        const lineTexts = useApiLines ? apiVocalTexts! : domLineTexts;
+        const lineTexts = sourceSelection.lineTexts;
         
         if (useApiLines) {
         } else if (apiVocalTexts) {
@@ -649,7 +761,7 @@ export async function translateCurrentLyrics(): Promise<void> {
             return;
         }
         
-        const detectedLang = apiLanguage || state.detectedLanguage || undefined;
+        const detectedLang = apiLanguage || cachedSourceLanguage || state.detectedLanguage || undefined;
 
         let skipCheck: { skip: boolean; reason?: string; detectedLanguage?: string };
         if (romanizationOn && apiLanguage) {

--- a/src/utils/initialize.ts
+++ b/src/utils/initialize.ts
@@ -35,7 +35,9 @@ export async function initialize(): Promise<void> {
         deeplApiKey: state.deeplApiKey,
         openaiApiKey: state.openaiApiKey,
         openaiModel: state.openaiModel,
-        geminiApiKey: state.geminiApiKey
+        geminiApiKey: state.geminiApiKey,
+        geminiModel: state.geminiModel,
+        geminiTemperature: state.geminiTemperature
     });
     injectStyles();
     initConnectionIndicator();

--- a/src/utils/lyricsFetcher.ts
+++ b/src/utils/lyricsFetcher.ts
@@ -3,6 +3,8 @@ import { normalizeLanguageCode } from './languageDetection';
 
 const SPICY_API_HOST = 'api.spicylyrics.org';
 const SPICY_QUERY_PATH = '/query';
+const SPICY_LYRICS_CACHE_NAME = 'SpicyLyrics_LyricsStore';
+const SPICY_LYRICS_CACHE_VERSION = 12;
 
 interface SyllableData {
     Text: string;
@@ -75,6 +77,13 @@ interface QueryResponse {
     }>;
 }
 
+interface SpicyLyricsCacheItem {
+    ExpiresAt?: number;
+    CacheVersion?: number;
+    Content?: any;
+    Value?: string;
+}
+
 const captureCache = new Map<string, LyricsData>();
 let interceptorInstalled = false;
 
@@ -122,6 +131,60 @@ function processCapturedResponse(trackId: string, payload: QueryResponse): void 
             return;
         }
     }
+}
+
+async function readSpicyLyricsCache(trackId: string): Promise<LyricsData | null> {
+    try {
+        if (!trackId || typeof caches === 'undefined' || typeof caches.open !== 'function') {
+            return null;
+        }
+
+        const cache = await caches.open(SPICY_LYRICS_CACHE_NAME);
+        const response = await cache.match(`/${trackId}`);
+        if (!response || typeof response.json !== 'function') {
+            return null;
+        }
+
+        const item = await response.json() as SpicyLyricsCacheItem | LyricsData;
+        if (isLyricsData(item)) {
+            return item;
+        }
+
+        if (!item || typeof item !== 'object' || item.Value === 'NO_LYRICS') {
+            return null;
+        }
+
+        if (typeof item.CacheVersion === 'number' && item.CacheVersion !== SPICY_LYRICS_CACHE_VERSION) {
+            return null;
+        }
+
+        if (typeof item.ExpiresAt === 'number' && item.ExpiresAt < Date.now()) {
+            return null;
+        }
+
+        const content = item.Content;
+        if (!content || content.Value === 'NO_LYRICS') {
+            return null;
+        }
+
+        return isLyricsData(content) ? content : null;
+    } catch (err) {
+        warn('Failed to read Spicy Lyrics cache:', err);
+        return null;
+    }
+}
+
+async function getStoredLyricsData(trackId: string): Promise<LyricsData | null> {
+    const captured = captureCache.get(trackId);
+    if (captured) return captured;
+
+    const cached = await readSpicyLyricsCache(trackId);
+    if (cached) {
+        captureCache.set(trackId, cached);
+        return cached;
+    }
+
+    return null;
 }
 
 function installFetchInterceptor(): void {
@@ -173,12 +236,21 @@ installFetchInterceptor();
 
 async function waitForCapture(trackId: string, timeoutMs: number = 8000, pollMs: number = 100): Promise<LyricsData | null> {
     const start = Date.now();
+    let nextStoreCheck = 0;
+
     while (Date.now() - start < timeoutMs) {
         const cached = captureCache.get(trackId);
         if (cached) return cached;
+
+        if (Date.now() >= nextStoreCheck) {
+            const stored = await getStoredLyricsData(trackId);
+            if (stored) return stored;
+            nextStoreCheck = Date.now() + 500;
+        }
+
         await new Promise(resolve => setTimeout(resolve, pollMs));
     }
-    return captureCache.get(trackId) ?? null;
+    return getStoredLyricsData(trackId);
 }
 
 
@@ -332,6 +404,22 @@ export function getCachedLineData(): LyricLineData[] | null {
     return cachedLineData;
 }
 
+function cacheParsedLyrics(trackId: string, lyrics: LyricsData): { lines: string[]; lineData: LyricLineData[]; language?: string } | null {
+    const lineData = extractLinesData(lyrics);
+    if (lineData.length === 0) {
+        return null;
+    }
+
+    cachedTrackId = trackId;
+    cachedLineData = lineData;
+    cachedLanguage = getLyricsLanguage(lyrics) || null;
+
+    return {
+        lines: lineData.map(l => l.text),
+        lineData,
+        language: cachedLanguage || undefined
+    };
+}
 
 export async function fetchLyricsFromAPI(): Promise<{ lines: string[]; lineData: LyricLineData[]; language?: string } | null> {
     const trackId = getCurrentTrackId();
@@ -348,22 +436,12 @@ export async function fetchLyricsFromAPI(): Promise<{ lines: string[]; lineData:
     }
 
     try {
-        const lyrics = await waitForCapture(trackId);
+        const lyrics = await getStoredLyricsData(trackId) || await waitForCapture(trackId);
         if (!lyrics) {
             return null;
         }
 
-        const lineData = extractLinesData(lyrics);
-        if (lineData.length === 0) {
-            return null;
-        }
-
-        cachedTrackId = trackId;
-        cachedLineData = lineData;
-        cachedLanguage = getLyricsLanguage(lyrics) || null;
-
-        const lines = lineData.map(l => l.text);
-        return { lines, lineData, language: cachedLanguage || undefined };
+        return cacheParsedLyrics(trackId, lyrics);
     } catch (err) {
         warn('Failed to capture lyrics from Spicy Lyrics fetch:', err);
         return null;
@@ -385,25 +463,12 @@ export async function fetchLyricsForTrackUri(trackUri: string): Promise<{ lines:
     }
 
     try {
-        const lyrics = await waitForCapture(trackId);
+        const lyrics = await getStoredLyricsData(trackId) || await waitForCapture(trackId);
         if (!lyrics) {
             return null;
         }
 
-        const lineData = extractLinesData(lyrics);
-        if (lineData.length === 0) {
-            return null;
-        }
-
-        cachedTrackId = trackId;
-        cachedLineData = lineData;
-        cachedLanguage = getLyricsLanguage(lyrics) || null;
-
-        return {
-            lines: lineData.map(l => l.text),
-            lineData,
-            language: cachedLanguage || undefined
-        };
+        return cacheParsedLyrics(trackId, lyrics);
     } catch (err) {
         warn('Failed to capture lyrics for track URI:', trackUri, err);
         return null;
@@ -415,6 +480,7 @@ export function clearLyricsCache(): void {
     cachedTrackId = null;
     cachedLineData = null;
     cachedLanguage = null;
+    captureCache.clear();
 }
 
 export default {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,13 +1,71 @@
 import { storage } from './storage';
 import { state } from './state';
 import { clearTranslationCache } from './translator';
-import { getTrackCacheStats, getAllCachedTracks, deleteTrackCache, clearAllTrackCache, getTrackCache } from './trackCache';
+import { getTrackCacheStats, getAllCachedTracks, deleteTrackCache, getTrackCache } from './trackCache';
 import { VERSION, REPO_URL, checkForUpdates, getUpdateInfo, showCurrentChangelog, getContentHashShort } from './updater';
 import { reapplyTranslations } from './core';
-import { fetchLyricsForTrackUri } from './lyricsFetcher';
+import { clearLyricsCache, fetchLyricsForTrackUri } from './lyricsFetcher';
 import { SETTINGS_SCHEMA, SettingsEffect, SettingsField, getCurrentApiPreference, isSettingFieldVisible, readSettingValue, writeSettingValue } from './settingsModel';
 
 const SETTINGS_ID = 'spicy-lyric-translator-settings';
+const SPICY_LYRICS_CACHE_NAME = 'SpicyLyrics_LyricsStore';
+
+function showActionNotification(message: string, isError: boolean = false): void {
+    if (state.showNotifications && Spicetify.showNotification) {
+        Spicetify.showNotification(message, isError);
+    }
+}
+
+export function clearAllCachedTranslations(): void {
+    clearTranslationCache();
+    showActionNotification('All cached translations deleted!');
+}
+
+export async function clearSpicyLyricsCachedLyrics(): Promise<void> {
+    try {
+        clearLyricsCache();
+        if (typeof caches !== 'undefined' && typeof caches.delete === 'function') {
+            await caches.delete(SPICY_LYRICS_CACHE_NAME);
+        }
+        showActionNotification('Spicy Lyrics cached lyrics deleted!');
+    } catch (e) {
+        showActionNotification('Failed to clear Spicy Lyrics cached lyrics', true);
+    }
+}
+
+export function renderModalCacheActionsMarkup(): string {
+    return `
+            <button class="slt-button secondary" id="slt-clear-spicy-lyrics-cache" type="button">Clear Spicy Lyrics Cache</button>
+            <button class="slt-button danger" id="slt-clear-translation-cache" type="button">Clear All Cached Translations</button>`;
+}
+
+export function bindModalCacheActions(container: ParentNode): void {
+    const spicyLyricsCacheButton = container.querySelector('#slt-clear-spicy-lyrics-cache') as HTMLButtonElement | null;
+    const translationCacheButton = container.querySelector('#slt-clear-translation-cache') as HTMLButtonElement | null;
+
+    spicyLyricsCacheButton?.addEventListener('click', async () => {
+        const previousText = spicyLyricsCacheButton.textContent || 'Clear Spicy Lyrics Cache';
+        spicyLyricsCacheButton.disabled = true;
+        spicyLyricsCacheButton.textContent = 'Clearing...';
+        await clearSpicyLyricsCachedLyrics();
+        spicyLyricsCacheButton.textContent = 'Cleared';
+        setTimeout(() => {
+            spicyLyricsCacheButton.disabled = false;
+            spicyLyricsCacheButton.textContent = previousText;
+        }, 1200);
+    });
+
+    translationCacheButton?.addEventListener('click', () => {
+        const previousText = translationCacheButton.textContent || 'Clear All Cached Translations';
+        translationCacheButton.disabled = true;
+        clearAllCachedTranslations();
+        translationCacheButton.textContent = 'Cleared';
+        setTimeout(() => {
+            translationCacheButton.disabled = false;
+            translationCacheButton.textContent = previousText;
+        }, 1200);
+    });
+}
 
 
 function createNativeToggle(id: string, label: string, checked: boolean, onChange: (checked: boolean) => void): HTMLElement {
@@ -181,13 +239,7 @@ function createNativeSettingsSection(): HTMLElement {
         'slt-settings.clear-cache',
         'Clear All Cached Translations',
         'Clear Cache',
-        () => {
-            clearAllTrackCache();
-            clearTranslationCache();
-            if (state.showNotifications && Spicetify.showNotification) {
-                Spicetify.showNotification('All cached translations deleted!');
-            }
-        }
+        clearAllCachedTranslations
     ));
     
     sectionContent.appendChild(createNativeButton(
@@ -566,6 +618,20 @@ function createSettingsUI(): HTMLElement {
                 background: var(--spice-card);
                 border: 1px solid var(--spice-button-disabled);
             }
+            .slt-button.danger {
+                background: rgba(255, 80, 80, 0.18);
+                border: 1px solid rgba(255, 80, 80, 0.35);
+                color: #ff7373;
+            }
+            .slt-button.danger:hover {
+                background: rgba(255, 80, 80, 0.3);
+                color: #fff;
+            }
+            .slt-button:disabled {
+                cursor: default;
+                opacity: 0.65;
+                transform: none;
+            }
             .slt-description {
                 display: block;
                 font-size: 12px;
@@ -585,6 +651,12 @@ function createSettingsUI(): HTMLElement {
             .slt-modal-actions {
                 border-top: 1px solid rgba(255, 255, 255, 0.08);
                 margin-top: 4px;
+            }
+            .slt-modal-cache-actions {
+                display: flex;
+                gap: 8px;
+                flex-wrap: wrap;
+                justify-content: flex-end;
             }
             .slt-modal-footer {
                 color: var(--spice-subtext);
@@ -623,6 +695,9 @@ function createSettingsUI(): HTMLElement {
 
         <div class="slt-modal-actions">
             <button class="slt-button secondary" id="slt-view-cache">View Translation Cache</button>
+            <div class="slt-modal-cache-actions">
+                ${renderModalCacheActionsMarkup()}
+            </div>
         </div>
         
         <div class="slt-modal-footer">
@@ -643,6 +718,7 @@ function createSettingsUI(): HTMLElement {
     
     setTimeout(() => {
         bindModalSettingsFields(container);
+        bindModalCacheActions(container);
         const viewCacheButton = container.querySelector('#slt-view-cache') as HTMLButtonElement;
         const viewChangelogPopupButton = container.querySelector('#slt-view-changelog-popup') as HTMLButtonElement;
         const checkUpdatesButton = container.querySelector('#slt-check-updates') as HTMLButtonElement;
@@ -1390,8 +1466,7 @@ function createCacheViewerUI(): HTMLElement {
         
         const deleteAllBtn = container.querySelector('#slt-delete-all-cache');
         deleteAllBtn?.addEventListener('click', () => {
-            clearAllTrackCache();
-            clearTranslationCache();
+            clearAllCachedTranslations();
             
             const tracksEl = container.querySelector('#slt-stat-tracks');
             const linesEl = container.querySelector('#slt-stat-lines');
@@ -1405,10 +1480,6 @@ function createCacheViewerUI(): HTMLElement {
             
             const actionsDiv = container.querySelector('.slt-cache-actions');
             if (actionsDiv) actionsDiv.remove();
-            
-            if (state.showNotifications && Spicetify.showNotification) {
-                Spicetify.showNotification('All cached translations deleted!');
-            }
         });
     }, 0);
     
@@ -1446,11 +1517,28 @@ export async function registerSettings(): Promise<void> {
         const registerMenuItem = () => {
             if ((Spicetify as any).Menu) {
                 try {
-                    new (Spicetify as any).Menu.Item(
-                        'Spicy Lyric Translator',
-                        false,
-                        openSettingsModal
-                    ).register();
+                    [
+                        {
+                            label: 'Spicy Lyric Translator Settings',
+                            callback: openSettingsModal
+                        },
+                        {
+                            label: 'Clear Spicy Lyrics Cache',
+                            callback: () => {
+                                void clearSpicyLyricsCachedLyrics();
+                            }
+                        },
+                        {
+                            label: 'Clear SLT Translation Cache',
+                            callback: clearAllCachedTranslations
+                        }
+                    ].forEach(item => {
+                        new (Spicetify as any).Menu.Item(
+                            item.label,
+                            false,
+                            item.callback
+                        ).register();
+                    });
                     return true;
                 } catch (e) {
                 }

--- a/src/utils/settingsModel.ts
+++ b/src/utils/settingsModel.ts
@@ -157,6 +157,26 @@ export const SETTINGS_SCHEMA: SettingsField[] = [
         visibleForApis: ['gemini']
     },
     {
+        id: 'gemini-model',
+        label: 'Gemini Model',
+        type: 'text',
+        storageKey: 'gemini-model',
+        defaultValue: 'gemini-2.0-flash',
+        placeholder: 'gemini-2.5-flash, gemini-2.0-flash',
+        description: 'Model name used in the Gemini generateContent endpoint',
+        visibleForApis: ['gemini']
+    },
+    {
+        id: 'gemini-temperature',
+        label: 'Gemini Temperature',
+        type: 'text',
+        storageKey: 'gemini-temperature',
+        defaultValue: '0.3',
+        placeholder: '0.0 - 2.0',
+        description: 'Controls Gemini output randomness',
+        visibleForApis: ['gemini']
+    },
+    {
         id: 'auto-translate',
         label: 'Auto-Translate on Song Change',
         type: 'toggle',
@@ -229,7 +249,9 @@ function configureTranslationApi(): void {
         deeplApiKey: state.deeplApiKey,
         openaiApiKey: state.openaiApiKey,
         openaiModel: state.openaiModel,
-        geminiApiKey: state.geminiApiKey
+        geminiApiKey: state.geminiApiKey,
+        geminiModel: state.geminiModel,
+        geminiTemperature: state.geminiTemperature
     });
 }
 
@@ -283,6 +305,14 @@ export function writeSettingValue(field: SettingsField, value: string | boolean)
             break;
         case 'gemini-api-key':
             state.geminiApiKey = String(value);
+            configureTranslationApi();
+            break;
+        case 'gemini-model':
+            state.geminiModel = String(value);
+            configureTranslationApi();
+            break;
+        case 'gemini-temperature':
+            state.geminiTemperature = String(value);
             configureTranslationApi();
             break;
         case 'auto-translate':

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -25,6 +25,8 @@ export interface ExtensionState {
     openaiApiKey: string;
     openaiModel: string;
     geminiApiKey: string;
+    geminiModel: string;
+    geminiTemperature: string;
     lastTranslatedSongUri: string | null;
     translatedLyrics: Map<string, string>;
     lastViewMode: string | null;
@@ -54,6 +56,8 @@ export const state: ExtensionState = {
     openaiApiKey: storage.getSecret('openai-api-key') || '',
     openaiModel: storage.get('openai-model') || 'gpt-4o-mini',
     geminiApiKey: storage.getSecret('gemini-api-key') || '',
+    geminiModel: storage.get('gemini-model') || 'gemini-2.0-flash',
+    geminiTemperature: storage.get('gemini-temperature') || '0.3',
     lastTranslatedSongUri: null,
     translatedLyrics: new Map(),
     lastViewMode: null,

--- a/src/utils/translationOverlay.ts
+++ b/src/utils/translationOverlay.ts
@@ -38,6 +38,16 @@ interface DocCache {
     lastActiveIndex: number;
 }
 
+export type VocabularyPairConfidence = 'high' | 'medium' | 'low';
+
+export interface VocabularyPairChunk {
+    original: string;
+    translated: string;
+    confidence: VocabularyPairConfidence;
+    sourceIndex: number;
+    translatedStart: number;
+}
+
 const docCacheMap = new WeakMap<Document, DocCache>();
 
 function getDocCache(doc: Document): DocCache {
@@ -328,7 +338,7 @@ function applyReplaceMode(doc: Document): void {
             replaceEl.classList.add('slt-replace-instrumental');
         } else {
             const vocabEnabled = storage.get('vocabulary-mode') === 'true';
-            const pairBelowText = romanizationMap.get(index) || originalTextMap.get(index) || originalText;
+            const pairBelowText = originalTextMap.get(index) || romanizationMap.get(index) || originalText;
             if (vocabEnabled) {
                 replaceEl.classList.add('slt-vocab-line');
                 appendVocabularyPairs(doc, replaceEl, pairBelowText, translation, line, 'slt-replace-word');
@@ -427,6 +437,277 @@ function appendTranslationWordSpans(
     });
 }
 
+const JAPANESE_TEXT_REGEX = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF]/u;
+const JAPANESE_FINAL_PARTICLES = ['かな', 'よね', 'だよ', 'だね', 'ね', 'な', 'よ', 'か', 'さ'];
+const JAPANESE_STATE_PREFIXES = [
+    'このまま',
+    'そのまま',
+    'あのまま',
+    'こんな',
+    'そんな',
+    'あんな',
+    'ここ',
+    'そこ',
+    'あそこ',
+    'これ',
+    'それ',
+    'あれ'
+];
+
+function normalizeVocabularyToken(text: string): string {
+    return (text || '')
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}?]+/gu, '')
+        .trim();
+}
+
+function splitTranslatedWords(text: string): string[] {
+    return (text || '').trim().split(/\s+/).filter(Boolean);
+}
+
+function splitJapaneseChunk(chunk: string): string[] {
+    let rest = chunk.trim();
+    const parts: string[] = [];
+    let finalParticle = '';
+
+    const finalMatch = [...JAPANESE_FINAL_PARTICLES]
+        .sort((a, b) => b.length - a.length)
+        .find(particle => rest.endsWith(particle) && rest.length > particle.length);
+    if (finalMatch) {
+        finalParticle = finalMatch;
+        rest = rest.slice(0, -finalMatch.length);
+    }
+
+    const prefix = [...JAPANESE_STATE_PREFIXES]
+        .sort((a, b) => b.length - a.length)
+        .find(candidate => rest.startsWith(candidate) && rest.length > candidate.length);
+    if (prefix) {
+        parts.push(prefix);
+        rest = rest.slice(prefix.length);
+    }
+
+    if (rest.trim()) {
+        parts.push(rest.trim());
+    }
+    if (finalParticle) {
+        parts.push(finalParticle);
+    }
+
+    return parts.length > 0 ? parts : [chunk];
+}
+
+function segmentVocabularySourceText(text: string): string[] {
+    const chunks = (text || '').trim().split(/\s+/).filter(Boolean);
+    if (chunks.length === 0) return [];
+
+    const segments: string[] = [];
+    for (const chunk of chunks) {
+        if (JAPANESE_TEXT_REGEX.test(chunk)) {
+            segments.push(...splitJapaneseChunk(chunk));
+        } else {
+            segments.push(chunk);
+        }
+    }
+
+    return segments.filter(Boolean);
+}
+
+function classifyJapaneseSourceUnit(text: string): 'state' | 'final' | 'content' {
+    if (JAPANESE_STATE_PREFIXES.some(prefix => text.startsWith(prefix))) return 'state';
+    if (JAPANESE_FINAL_PARTICLES.includes(text)) return 'final';
+    return 'content';
+}
+
+function translatedPhraseRange(
+    translatedWords: string[],
+    phrases: string[][],
+    usedIndexes: Set<number>,
+    preferEnd: boolean = false
+): { start: number; end: number } | null {
+    const normalizedWords = translatedWords.map(normalizeVocabularyToken);
+    const normalizedPhrases = phrases
+        .map(phrase => phrase.map(normalizeVocabularyToken).filter(Boolean))
+        .filter(phrase => phrase.length > 0)
+        .sort((a, b) => b.length - a.length);
+
+    for (const phrase of normalizedPhrases) {
+        const starts = normalizedWords
+            .map((_, index) => index)
+            .filter(index => index + phrase.length <= normalizedWords.length);
+        if (preferEnd) starts.reverse();
+
+        for (const start of starts) {
+            const end = start + phrase.length;
+            let matches = true;
+            for (let i = start; i < end; i++) {
+                if (usedIndexes.has(i) || normalizedWords[i] !== phrase[i - start]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return { start, end };
+        }
+    }
+
+    return null;
+}
+
+function contiguousUnusedRanges(totalWords: number, usedIndexes: Set<number>): Array<{ start: number; end: number }> {
+    const ranges: Array<{ start: number; end: number }> = [];
+    let start = -1;
+
+    for (let i = 0; i < totalWords; i++) {
+        if (!usedIndexes.has(i)) {
+            if (start === -1) start = i;
+        } else if (start !== -1) {
+            ranges.push({ start, end: i });
+            start = -1;
+        }
+    }
+    if (start !== -1) ranges.push({ start, end: totalWords });
+
+    return ranges;
+}
+
+function phraseFromRange(words: string[], range: { start: number; end: number }): string {
+    return words.slice(range.start, range.end).join(' ').trim();
+}
+
+function alignJapaneseVocabularyPairs(
+    sourceUnits: string[],
+    translatedWords: string[],
+    originalText: string,
+    translatedText: string
+): VocabularyPairChunk[] {
+    const usedTranslatedIndexes = new Set<number>();
+    const assignments = new Map<number, VocabularyPairChunk>();
+    let semanticMatches = 0;
+
+    sourceUnits.forEach((unit, sourceIndex) => {
+        const kind = classifyJapaneseSourceUnit(unit);
+        const range = kind === 'state'
+            ? translatedPhraseRange(translatedWords, [
+                ['the', 'nay'],
+                ['nhu', 'vay'],
+                ['nhu', 'the'],
+                ['vay'],
+                ['this', 'way'],
+                ['like', 'this'],
+                ['as', 'it', 'is'],
+                ['as', 'is']
+            ], usedTranslatedIndexes)
+            : kind === 'final'
+                ? translatedPhraseRange(translatedWords, [
+                    ['thoi'],
+                    ['nhe'],
+                    ['nhi'],
+                    ['day'],
+                    ['ha'],
+                    ['sao'],
+                    ['?']
+                ], usedTranslatedIndexes, true)
+                : null;
+
+        if (!range) return;
+
+        for (let i = range.start; i < range.end; i++) usedTranslatedIndexes.add(i);
+        semanticMatches++;
+        assignments.set(sourceIndex, {
+            original: unit,
+            translated: phraseFromRange(translatedWords, range),
+            confidence: 'high',
+            sourceIndex,
+            translatedStart: range.start
+        });
+    });
+
+    if (semanticMatches === 0) {
+        return [{
+            original: originalText.trim(),
+            translated: translatedText.trim(),
+            confidence: 'low',
+            sourceIndex: 0,
+            translatedStart: 0
+        }];
+    }
+
+    const unassignedSourceIndexes = sourceUnits
+        .map((_, index) => index)
+        .filter(index => !assignments.has(index));
+    const remainingRanges = contiguousUnusedRanges(translatedWords.length, usedTranslatedIndexes)
+        .filter(range => range.end > range.start);
+
+    if (unassignedSourceIndexes.length === 1 && remainingRanges.length > 0) {
+        const sourceIndex = unassignedSourceIndexes[0];
+        const first = remainingRanges[0];
+        const last = remainingRanges[remainingRanges.length - 1];
+        assignments.set(sourceIndex, {
+            original: sourceUnits[sourceIndex],
+            translated: phraseFromRange(translatedWords, { start: first.start, end: last.end }),
+            confidence: 'medium',
+            sourceIndex,
+            translatedStart: first.start
+        });
+    } else if (unassignedSourceIndexes.length > 1 && remainingRanges.length > 0) {
+        const remainingText = remainingRanges
+            .map(range => phraseFromRange(translatedWords, range))
+            .join(' ')
+            .trim();
+        const translatedBuckets = distributeWords(splitTranslatedWords(remainingText), unassignedSourceIndexes.length);
+        unassignedSourceIndexes.forEach((sourceIndex, bucketIndex) => {
+            if (!translatedBuckets[bucketIndex]) return;
+            assignments.set(sourceIndex, {
+                original: sourceUnits[sourceIndex],
+                translated: translatedBuckets[bucketIndex],
+                confidence: 'low',
+                sourceIndex,
+                translatedStart: remainingRanges[0].start + bucketIndex
+            });
+        });
+    }
+
+    const pairs = Array.from(assignments.values())
+        .filter(pair => pair.original.trim() && pair.translated.trim())
+        .sort((a, b) => a.translatedStart - b.translatedStart || a.sourceIndex - b.sourceIndex);
+
+    return pairs.length > 0 ? pairs : [{
+        original: originalText.trim(),
+        translated: translatedText.trim(),
+        confidence: 'low',
+        sourceIndex: 0,
+        translatedStart: 0
+    }];
+}
+
+export function buildVocabularyPairs(originalText: string, translatedText: string): VocabularyPairChunk[] {
+    const original = (originalText || '').trim();
+    const translated = (translatedText || '').trim();
+    const sourceUnits = segmentVocabularySourceText(original);
+    const translatedWords = splitTranslatedWords(translated);
+
+    if (sourceUnits.length === 0 || translatedWords.length === 0) {
+        return [];
+    }
+
+    if (JAPANESE_TEXT_REGEX.test(original)) {
+        return alignJapaneseVocabularyPairs(sourceUnits, translatedWords, original, translated);
+    }
+
+    const pairCount = Math.min(sourceUnits.length, translatedWords.length);
+    const originalChunks = distributeWords(sourceUnits, pairCount);
+    const translatedChunks = distributeWords(translatedWords, pairCount);
+
+    return originalChunks.map((chunk, index) => ({
+        original: chunk,
+        translated: translatedChunks[index],
+        confidence: 'medium',
+        sourceIndex: index,
+        translatedStart: index
+    }));
+}
+
 function appendVocabularyPairs(
     doc: Document,
     container: HTMLElement,
@@ -435,31 +716,26 @@ function appendVocabularyPairs(
     originalLine: Element,
     wordClassName: 'slt-sync-word' | 'slt-replace-word'
 ): void {
-    const origWords = originalText.trim().split(/\s+/).filter(Boolean);
-    const transWords = translatedText.trim().split(/\s+/).filter(Boolean);
+    const pairs = buildVocabularyPairs(originalText, translatedText);
 
-    if (origWords.length === 0 || transWords.length === 0) {
+    if (pairs.length === 0) {
         container.textContent = translatedText;
         return;
     }
 
     const originalWordUnits = getWordUnits(originalLine);
 
-    // Use the shorter list to determine pair count, distribute longer list across pairs
-    const pairCount = Math.min(origWords.length, transWords.length);
-    const origChunks = distributeWords(origWords, pairCount);
-    const transChunks = distributeWords(transWords, pairCount);
-
-    const transRatio = transWords.length / Math.max(originalWordUnits.length, 1);
-
     let globalWordIndex = 0;
+    const origChunks = pairs.map(pair => pair.original);
+    const transChunks = pairs.map(pair => pair.translated);
 
-    for (let i = 0; i < pairCount; i++) {
+    for (const [i, vocabPair] of pairs.entries()) {
         const pair = doc.createElement('span');
         pair.className = 'slt-vocab-pair';
+        pair.dataset.confidence = vocabPair.confidence;
 
         // Translated word(s) — gradient-synced span
-        const chunkWords = transChunks[i].split(/\s+/).filter(Boolean);
+        const chunkWords = splitTranslatedWords(vocabPair.translated);
         const transSpan = doc.createElement('span');
         transSpan.className = `slt-vocab-translated ${wordClassName}`;
 
@@ -470,11 +746,11 @@ function appendVocabularyPairs(
         }
 
         const mappedOriginalIndex = originalWordUnits.length > 0
-            ? Math.min(Math.floor(globalWordIndex / Math.max(transRatio, 0.01)), originalWordUnits.length - 1)
-            : globalWordIndex;
+            ? Math.min(vocabPair.sourceIndex, originalWordUnits.length - 1)
+            : vocabPair.sourceIndex;
         transSpan.dataset.originalIndex = Math.max(0, mappedOriginalIndex).toString();
         transSpan.dataset.wordIndex = globalWordIndex.toString();
-        transSpan.textContent = transChunks[i];
+        transSpan.textContent = vocabPair.translated;
         pair.appendChild(transSpan);
 
         globalWordIndex += chunkWords.length;
@@ -482,7 +758,7 @@ function appendVocabularyPairs(
         // Original annotation — blurred below
         const origSpan = doc.createElement('span');
         origSpan.className = 'slt-vocab-original';
-        origSpan.textContent = origChunks[i];
+        origSpan.textContent = vocabPair.original;
         pair.appendChild(origSpan);
 
         pair.title = `${origChunks[i]}  →  ${transChunks[i]}`;
@@ -777,7 +1053,7 @@ function applyInterleavedMode(doc: Document): void {
                 translationEl.dataset.lineIndex = index.toString();
 
                 const isVocabMode = storage.get('vocabulary-mode') === 'true';
-                const pairBelowText = romanizationMap.get(index) || originalTextMap.get(index) || originalText;
+                const pairBelowText = originalTextMap.get(index) || romanizationMap.get(index) || originalText;
 
                 if (isBreak) {
                     translationEl.textContent = '• • •';

--- a/src/utils/translator.ts
+++ b/src/utils/translator.ts
@@ -41,6 +41,8 @@ let deeplApiKey: string = '';
 let openaiApiKey: string = '';
 let openaiModel: string = 'gpt-4o-mini';
 let geminiApiKey: string = '';
+let geminiModel: string = 'gemini-2.0-flash';
+let geminiTemperature: number = 0.3;
 
 const RATE_LIMIT = {
     minDelayMs: 100,
@@ -56,6 +58,7 @@ const BATCH_SEPARATOR_REGEX = /\s*\|\|\|\s*/g;
 const BATCH_MARKER_PREFIX = '[[SLT_BATCH_';
 const BATCH_CHUNK_SIZE = 6;
 const NON_LATIN_SEGMENT_REGEX = /([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Cyrillic}\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Devanagari}\p{Script=Greek}]+)/gu;
+const SPICETIFY_CORS_PROXY_BASE = 'https://cors-proxy.spicetify.app/';
 
 function normalizeSourceLineForFingerprint(line: string): string {
     return (line || '')
@@ -289,6 +292,157 @@ async function rateLimitedDelay(): Promise<void> {
     lastApiCallTime = Date.now();
 }
 
+type ApiKeyConfig = {
+    customApiKey?: string;
+    customApiFormat?: CustomApiFormat;
+    customApiModel?: string;
+    deeplApiKey?: string;
+    openaiApiKey?: string;
+    openaiModel?: string;
+    geminiApiKey?: string;
+    geminiModel?: string;
+    geminiTemperature?: string | number;
+};
+
+type CosmosAsyncClient = {
+    post?: (url: string, body?: unknown, headers?: Record<string, string>) => Promise<unknown>;
+};
+
+function getCosmosAsync(): CosmosAsyncClient | null {
+    try {
+        return (globalThis as any).Spicetify?.CosmosAsync || null;
+    } catch {
+        return null;
+    }
+}
+
+function isLikelyCorsOrNetworkError(err: unknown): boolean {
+    if (err instanceof TypeError) return true;
+    const message = err instanceof Error ? err.message : String(err || '');
+    return /failed to fetch|networkerror|cors|load failed/i.test(message);
+}
+
+class NonRetryableProviderError extends Error {
+    constructor(message: string, readonly status?: number) {
+        super(message);
+        this.name = 'NonRetryableProviderError';
+    }
+}
+
+function isNonRetryableProviderError(err: unknown): boolean {
+    if (err instanceof NonRetryableProviderError) return true;
+    const message = err instanceof Error ? err.message : String(err || '');
+    const statusMatch = message.match(/\b(4\d\d)\b/);
+    if (!statusMatch) return false;
+    const status = Number(statusMatch[1]);
+    return status !== 408 && status !== 429;
+}
+
+function createProviderHttpError(providerName: string, status: number, errorText: string): Error {
+    const message = `${providerName} API error: ${status}${errorText ? ` ${errorText.slice(0, 160)}` : ''}`;
+    if (status >= 400 && status < 500 && status !== 408 && status !== 429) {
+        return new NonRetryableProviderError(message, status);
+    }
+    return new Error(message);
+}
+
+function getSpicetifyCorsProxyUrl(url: string): string {
+    return `${SPICETIFY_CORS_PROXY_BASE}${url}`;
+}
+
+async function postJsonProvider(
+    url: string,
+    body: unknown,
+    headers: Record<string, string>,
+    providerName: string,
+    options: { preferCosmos?: boolean } = {}
+): Promise<any> {
+    const cosmos = getCosmosAsync();
+
+    if (options.preferCosmos && cosmos?.post) {
+        return cosmos.post(url, body, headers);
+    }
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body)
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text().catch(() => '');
+            throw createProviderHttpError(providerName, response.status, errorText);
+        }
+
+        return await response.json();
+    } catch (err) {
+        if (cosmos?.post && isLikelyCorsOrNetworkError(err)) {
+            return cosmos.post(url, body, headers);
+        }
+        throw err;
+    }
+}
+
+function buildLibreTranslateForm(text: string | string[], targetLang: string): URLSearchParams {
+    const params = new URLSearchParams();
+    const values = Array.isArray(text) ? text : [text];
+    values.forEach(value => params.append('q', value));
+    params.set('source', 'auto');
+    params.set('target', targetLang);
+    params.set('format', 'text');
+    return params;
+}
+
+function formToJsonObject(params: URLSearchParams): Record<string, string | string[]> {
+    const result: Record<string, string | string[]> = {};
+
+    params.forEach((value, key) => {
+        const existing = result[key];
+        if (existing === undefined) {
+            result[key] = value;
+        } else if (Array.isArray(existing)) {
+            existing.push(value);
+        } else {
+            result[key] = [existing, value];
+        }
+    });
+
+    return result;
+}
+
+async function postFormProvider(
+    url: string,
+    params: URLSearchParams,
+    providerName: string,
+    options: { preferCosmos?: boolean } = {}
+): Promise<any> {
+    const cosmos = getCosmosAsync();
+
+    if (options.preferCosmos && cosmos?.post) {
+        return cosmos.post(url, formToJsonObject(params), { 'Content-Type': 'application/json' });
+    }
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            body: params
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text().catch(() => '');
+            throw createProviderHttpError(providerName, response.status, errorText);
+        }
+
+        return await response.json();
+    } catch (err) {
+        if (cosmos?.post && isLikelyCorsOrNetworkError(err)) {
+            return cosmos.post(url, formToJsonObject(params), { 'Content-Type': 'application/json' });
+        }
+        throw err;
+    }
+}
+
 async function retryWithBackoff<T>(
     fn: () => Promise<T>,
     maxRetries: number = RATE_LIMIT.maxRetries,
@@ -303,7 +457,7 @@ async function retryWithBackoff<T>(
         } catch (error) {
             lastError = error as Error;
             
-            if (error instanceof Error && error.message.includes('40')) {
+            if (isNonRetryableProviderError(error)) {
                 throw error;
             }
             
@@ -320,7 +474,7 @@ async function retryWithBackoff<T>(
     throw lastError || new Error('All retry attempts failed');
 }
 
-export function setPreferredApi(api: ApiPreference, customUrl?: string, apiKeys?: { customApiKey?: string; customApiFormat?: CustomApiFormat; customApiModel?: string; deeplApiKey?: string; openaiApiKey?: string; openaiModel?: string; geminiApiKey?: string }): void {
+export function setPreferredApi(api: ApiPreference, customUrl?: string, apiKeys?: ApiKeyConfig): void {
     preferredApi = api;
     if (customUrl !== undefined) {
         customApiUrl = customUrl;
@@ -333,6 +487,8 @@ export function setPreferredApi(api: ApiPreference, customUrl?: string, apiKeys?
         if (apiKeys.openaiApiKey !== undefined) openaiApiKey = apiKeys.openaiApiKey;
         if (apiKeys.openaiModel !== undefined) openaiModel = apiKeys.openaiModel;
         if (apiKeys.geminiApiKey !== undefined) geminiApiKey = apiKeys.geminiApiKey;
+        if (apiKeys.geminiModel !== undefined) geminiModel = apiKeys.geminiModel;
+        if (apiKeys.geminiTemperature !== undefined) geminiTemperature = normalizeGeminiTemperature(apiKeys.geminiTemperature);
     }
 }
 
@@ -584,25 +740,13 @@ async function translateWithGoogle(text: string, targetLang: string, sourceLang?
 
 async function translateWithLibreTranslate(text: string, targetLang: string): Promise<string> {
     const url = 'https://libretranslate.de/translate';
-    
-    const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            q: text,
-            source: 'auto',
-            target: targetLang,
-            format: 'text'
-        })
-    });
-    
-    if (!response.ok) {
-        throw new Error(`LibreTranslate API error: ${response.status}`);
-    }
-    
-    const data = await response.json();
+
+    const data = await postFormProvider(
+        url,
+        buildLibreTranslateForm(text, targetLang),
+        'LibreTranslate',
+        { preferCosmos: true }
+    );
     return data.translatedText;
 }
 
@@ -615,29 +759,12 @@ async function translateWithDeepL(text: string, targetLang: string): Promise<{ t
     const baseUrl = isFreePlan ? 'https://api-free.deepl.com' : 'https://api.deepl.com';
     const url = `${baseUrl}/v2/translate`;
     
-    const deeplLangMap: Record<string, string> = {
-        'en': 'EN-US', 'pt': 'PT-BR', 'zh': 'ZH-HANS', 'zh-TW': 'ZH-HANT'
-    };
-    const deeplTarget = deeplLangMap[targetLang] || targetLang.toUpperCase();
-    
-    const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-            'Authorization': `DeepL-Auth-Key ${deeplApiKey}`,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            text: [text],
-            target_lang: deeplTarget
-        })
-    });
-    
-    if (!response.ok) {
-        const errorText = await response.text().catch(() => '');
-        throw new Error(`DeepL API error: ${response.status}`);
-    }
-    
-    const data = await response.json();
+    const data = await postJsonProvider(
+        getSpicetifyCorsProxyUrl(url),
+        buildDeepLBody([text], targetLang),
+        getDeepLHeaders(deeplApiKey),
+        'DeepL'
+    );
     
     if (data.translations && data.translations.length > 0) {
         return {
@@ -696,6 +823,24 @@ async function translateWithOpenAI(text: string, targetLang: string): Promise<{ 
     throw new Error('Invalid response from OpenAI API');
 }
 
+function normalizeGeminiModelName(model: string | undefined): string {
+    const trimmed = (model || '').trim().replace(/^models\//, '');
+    return trimmed || 'gemini-2.0-flash';
+}
+
+function normalizeGeminiTemperature(value: string | number | undefined): number {
+    const parsed = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''));
+    if (!Number.isFinite(parsed)) {
+        return 0.3;
+    }
+    return Math.min(2, Math.max(0, parsed));
+}
+
+function getGeminiGenerateContentUrl(model: string | undefined): string {
+    const normalizedModel = normalizeGeminiModelName(model);
+    return `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(normalizedModel)}:generateContent`;
+}
+
 async function translateWithGemini(text: string, targetLang: string): Promise<{ translation: string; detectedLang?: string }> {
     if (!geminiApiKey) {
         throw new Error('Gemini API key not configured. Set it in Settings.');
@@ -703,7 +848,7 @@ async function translateWithGemini(text: string, targetLang: string): Promise<{ 
 
     const langName = SUPPORTED_LANGUAGES.find(l => l.code === targetLang)?.name || targetLang;
 
-    const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent', {
+    const response = await fetch(getGeminiGenerateContentUrl(geminiModel), {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -720,7 +865,7 @@ async function translateWithGemini(text: string, targetLang: string): Promise<{ 
                 }
             ],
             generationConfig: {
-                temperature: 0.3,
+                temperature: geminiTemperature,
                 maxOutputTokens: Math.max(text.length * 3, 500)
             }
         })
@@ -768,6 +913,20 @@ function getDeepLTargetLanguage(targetLang: string): string {
         'en': 'EN-US', 'pt': 'PT-BR', 'zh': 'ZH-HANS', 'zh-TW': 'ZH-HANT'
     };
     return deeplLangMap[targetLang] || targetLang.toUpperCase();
+}
+
+function buildDeepLBody(texts: string[], targetLang: string): { text: string[]; target_lang: string } {
+    return {
+        text: texts,
+        target_lang: getDeepLTargetLanguage(targetLang)
+    };
+}
+
+function getDeepLHeaders(apiKey: string): Record<string, string> {
+    return {
+        'Authorization': `DeepL-Auth-Key ${apiKey}`,
+        'Content-Type': 'application/json'
+    };
 }
 
 function getTranslationLanguageName(targetLang: string): string {
@@ -838,7 +997,7 @@ function buildCustomSingleBody(text: string, targetLang: string, format: CustomA
                 }
             ],
             generationConfig: {
-                temperature: 0.3,
+                temperature: geminiTemperature,
                 maxOutputTokens: Math.max(text.length * 3, 500)
             }
         };
@@ -998,30 +1157,23 @@ async function translateBatchArray(texts: string[], targetLang: string): Promise
     }
 
     if ((preferredApi === 'deepl' && deeplApiKey) || (preferredApi === 'custom' && customApiFormat === 'deepl')) {
-        const isFreePlan = deeplApiKey.endsWith(':fx');
+        const selectedDeepLKey = preferredApi === 'custom' ? customApiKey : deeplApiKey;
+        const isFreePlan = selectedDeepLKey.endsWith(':fx');
         const baseUrl = isFreePlan ? 'https://api-free.deepl.com' : 'https://api.deepl.com';
         const url = preferredApi === 'custom' ? validateCustomApiUrl() : `${baseUrl}/v2/translate`;
-        const headers = preferredApi === 'custom'
-            ? getCustomApiHeaders('deepl')
-            : {
-                'Authorization': `DeepL-Auth-Key ${deeplApiKey}`,
-                'Content-Type': 'application/json'
-            };
-
-        const response = await fetch(url, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({
-                text: texts,
-                target_lang: getDeepLTargetLanguage(targetLang)
-            })
-        });
-
-        if (!response.ok) {
-            throw new Error(`DeepL batch API error: ${response.status}`);
-        }
-
-        const data = await response.json();
+        const data = preferredApi === 'deepl'
+            ? await postJsonProvider(
+                getSpicetifyCorsProxyUrl(url),
+                buildDeepLBody(texts, targetLang),
+                getDeepLHeaders(selectedDeepLKey),
+                'DeepL batch'
+            )
+            : await postJsonProvider(
+                url,
+                buildDeepLBody(texts, targetLang),
+                getCustomApiHeaders('deepl'),
+                'DeepL batch'
+            );
         if (data.translations && Array.isArray(data.translations)) {
             return {
                 translations: data.translations.map((t: any) => t.text || ''),
@@ -1043,31 +1195,26 @@ async function translateBatchArray(texts: string[], targetLang: string): Promise
         throw new Error('Custom API URL not configured');
     }
 
-    const headers = preferredApi === 'custom'
-        ? getCustomApiHeaders(customApiFormat || 'generic')
-        : {
-            'Content-Type': 'application/json'
-        };
-
-    const response = await fetch(url, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-            q: texts,
-            text: texts,
-            source: 'auto',
-            target: targetLang,
-            target_lang: targetLang,
-            format: 'text'
-        })
-    });
-
-    if (!response.ok) {
-        const errorBody = await response.text().catch(() => '');
-        throw new Error(`Batch API error: ${response.status}`);
-    }
-
-    const data = await response.json();
+    const data = preferredApi === 'libretranslate'
+        ? await postFormProvider(
+            url,
+            buildLibreTranslateForm(texts.join('\n'), targetLang),
+            'LibreTranslate batch',
+            { preferCosmos: true }
+        )
+        : await postJsonProvider(
+            url,
+            {
+                q: texts,
+                text: texts,
+                source: 'auto',
+                target: targetLang,
+                target_lang: targetLang,
+                format: 'text'
+            },
+            getCustomApiHeaders(customApiFormat || 'generic'),
+            'Batch API'
+        );
     const normalized = normalizeBatchTranslations(data);
     if (normalized) {
         return normalized;
@@ -1091,6 +1238,10 @@ function buildMarkedBatchPayload(lines: string[]): { combinedText: string; marke
         .map((line, index) => `${BATCH_MARKER_PREFIX}${markerNonce}_${index}]]${line}`)
         .join('\n');
     return { combinedText, markerNonce };
+}
+
+function hasInternalBatchMarkers(text: string): boolean {
+    return (text || '').includes(BATCH_MARKER_PREFIX) || /\[\[\s*SLT[\s_-]*BATCH/i.test(text || '');
 }
 
 function parseMarkedBatchResponse(translatedText: string, expectedCount: number, markerNonce: string): string[] | null {
@@ -1135,6 +1286,7 @@ function parseMarkedBatchResponse(translatedText: string, expectedCount: number,
 
 function normalizeTranslatedLine(text: string): string {
     return text
+        .replace(/```[a-z0-9_-]*/gi, '')
         .replace(/\[\[\s*SLT[\s_-]*BATCH[^\]]*\]\]/gi, '')
         .replace(/\[\[\s*[A-Za-z0-9]+[_\s-]*BATCH[_\s-]*[A-Za-z0-9]*[_\s-]*\d+\s*\]\]/gi, '')
         .replace(/\[\[\s*[A-Za-z0-9_\s-]*\d+\s*\]\]/g, '')
@@ -1145,15 +1297,39 @@ function normalizeTranslatedLine(text: string): string {
         .trim();
 }
 
+function foldWrapperLineForComparison(text: string): string {
+    return (text || '')
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .trim();
+}
+
+function isBatchWrapperLine(line: string): boolean {
+    const folded = foldWrapperLineForComparison(line);
+    if (!folded) return true;
+    if (/^```/.test(folded)) return true;
+    return /^(here('|')?s|here is|here are|sure[,!. ]|translation:?|translated lyrics:?|ban dich:?|duoi day|day la)/.test(folded);
+}
+
+function removeBatchWrapperLines(text: string): string {
+    return (text || '')
+        .split(/\r?\n/)
+        .filter(line => !isBatchWrapperLine(line))
+        .join('\n');
+}
+
 function parseBatchTextFallbacks(translatedText: string, expectedCount: number): string[] | null {
-    const separatorSplit = translatedText
+    const batchText = removeBatchWrapperLines(translatedText);
+
+    const separatorSplit = batchText
         .split(BATCH_SEPARATOR_REGEX)
         .map(s => normalizeTranslatedLine(s));
     if (separatorSplit.length === expectedCount) {
         return separatorSplit;
     }
 
-    const newlineSplit = translatedText
+    const newlineSplit = batchText
         .split(/\r?\n+/)
         .map(s => normalizeTranslatedLine(s))
         .filter(Boolean);
@@ -1217,6 +1393,9 @@ async function translateSourceAlignedBatch(lines: string[], targetLang: string, 
                 return batchResult;
             }
         } catch (batchArrayError) {
+            if (isNonRetryableProviderError(batchArrayError)) {
+                throw batchArrayError;
+            }
             warn('Source-aligned batch-array translation unavailable, falling back to marker batching:', batchArrayError);
         }
     }
@@ -1380,6 +1559,13 @@ export async function translateText(text: string, targetLang: string, sourceLang
             wasTranslated: true
         };
     } catch (primaryError) {
+        if (isNonRetryableProviderError(primaryError)) {
+            throw primaryError;
+        }
+        if (hasInternalBatchMarkers(text)) {
+            const message = primaryError instanceof Error ? primaryError.message : String(primaryError || 'Provider failed');
+            throw new NonRetryableProviderError(message);
+        }
         warn(`Primary API (${preferredApi}) failed, trying fallbacks:`, primaryError);
         
         for (const fallbackApi of fallbackApis) {
@@ -1519,6 +1705,9 @@ export async function translateLyrics(
                     detectedLang = batchResult.detectedLang;
                 }
             } catch (batchArrayError) {
+                if (isNonRetryableProviderError(batchArrayError)) {
+                    throw batchArrayError;
+                }
                 warn('Batch-array translation unavailable, falling back to marker batching:', batchArrayError);
             }
         }

--- a/tests/core-source-selection.test.ts
+++ b/tests/core-source-selection.test.ts
@@ -1,0 +1,133 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { LyricLineData } from '../src/utils/lyricsFetcher';
+import type {
+    isRomanizationActive as IsRomanizationActive,
+    resolveTranslationSourceLines as ResolveTranslationSourceLines
+} from '../src/utils/core';
+
+(globalThis as any).window = {
+    setTimeout,
+    clearTimeout,
+    location: { pathname: '', href: '', reload: () => {} },
+    addEventListener: () => {},
+    removeEventListener: () => {}
+};
+(globalThis as any).document = {
+    querySelector: () => null
+};
+
+const { isRomanizationActive, resolveTranslationSourceLines } = require('../src/utils/core') as {
+    isRomanizationActive: typeof IsRomanizationActive;
+    resolveTranslationSourceLines: typeof ResolveTranslationSourceLines;
+};
+
+function vocalLine(text: string, romanizedText?: string): LyricLineData {
+    return {
+        text,
+        romanizedText,
+        startTime: 0,
+        endTime: 1000,
+        isInstrumental: false
+    };
+}
+
+test('romanization mode translates API original lyrics instead of DOM romanized lyrics', () => {
+    const originalLines = ['\u541b\u306f\u4e16\u754c', '\u611b\u3057\u3066\u308b'];
+    const romanizedLines = ['kimi wa sekai', 'ai shiteru'];
+    const apiLineData = originalLines.map((line, index) => vocalLine(line, romanizedLines[index]));
+
+    const result = resolveTranslationSourceLines({
+        domLineTexts: romanizedLines,
+        romanizationOn: true,
+        apiVocalTexts: originalLines,
+        apiVocalLineData: apiLineData
+    });
+
+    assert.equal(result.canTranslate, true);
+    assert.equal(result.useApiLines, true);
+    assert.deepEqual(result.lineTexts, originalLines);
+    assert.deepEqual(result.lineTexts.filter(line => romanizedLines.includes(line)), []);
+});
+
+test('detects Spicy Lyrics romanization storage key', () => {
+    (globalThis as any).Spicetify = {
+        LocalStorage: {
+            get: (key: string) => key === 'SpicyLyrics-romanization' ? 'true' : null
+        }
+    };
+    (globalThis as any).localStorage = {
+        getItem: () => null
+    };
+
+    assert.equal(isRomanizationActive(), true);
+});
+
+test('romanization mode does not fall back to DOM romanized lyrics when API originals are missing', () => {
+    const romanizedLines = ['kimi wa sekai', 'ai shiteru'];
+
+    const result = resolveTranslationSourceLines({
+        domLineTexts: romanizedLines,
+        romanizationOn: true,
+        apiVocalTexts: null,
+        apiVocalLineData: null,
+        cachedSourceLines: null
+    });
+
+    assert.equal(result.canTranslate, false);
+    assert.equal(result.reason, 'missing-original-lyrics');
+    assert.deepEqual(result.lineTexts, []);
+});
+
+test('romanization mode reuses cached original source lines when API capture is unavailable', () => {
+    const cachedOriginalLines = ['\u541b\u306f\u4e16\u754c', '\u611b\u3057\u3066\u308b'];
+    const romanizedLines = ['kimi wa sekai', 'ai shiteru'];
+
+    const result = resolveTranslationSourceLines({
+        domLineTexts: romanizedLines,
+        romanizationOn: true,
+        apiVocalTexts: null,
+        apiVocalLineData: null,
+        cachedSourceLines: cachedOriginalLines
+    });
+
+    assert.equal(result.canTranslate, true);
+    assert.equal(result.useApiLines, true);
+    assert.deepEqual(result.lineTexts, cachedOriginalLines);
+    assert.deepEqual(result.lineTexts.filter(line => romanizedLines.includes(line)), []);
+});
+
+test('romanization mode rejects cached source lines that are already romanized', () => {
+    const romanizedLines = ['kimi wa sekai', 'ai shiteru'];
+
+    const result = resolveTranslationSourceLines({
+        domLineTexts: romanizedLines,
+        romanizationOn: true,
+        apiVocalTexts: null,
+        apiVocalLineData: null,
+        cachedSourceLines: romanizedLines
+    });
+
+    assert.equal(result.canTranslate, false);
+    assert.equal(result.reason, 'missing-original-lyrics');
+    assert.deepEqual(result.lineTexts, []);
+});
+
+test('romanization mode pads missing API lines with empty text instead of DOM romanized text', () => {
+    const originalLines = ['\u541b\u306f\u4e16\u754c'];
+    const romanizedLines = ['kimi wa sekai', 'ai shiteru'];
+    const apiLineData = [vocalLine(originalLines[0], romanizedLines[0])];
+
+    const result = resolveTranslationSourceLines({
+        domLineTexts: romanizedLines,
+        romanizationOn: true,
+        apiVocalTexts: originalLines,
+        apiVocalLineData: apiLineData,
+        cachedSourceLines: null
+    });
+
+    assert.equal(result.canTranslate, true);
+    assert.deepEqual(result.lineTexts, [originalLines[0], '']);
+    assert.deepEqual(result.lineTexts.filter(line => romanizedLines.includes(line)), []);
+    assert.equal(result.apiVocalLineData?.[1]?.text, '');
+});

--- a/tests/lyrics-fetcher-cache.test.ts
+++ b/tests/lyrics-fetcher-cache.test.ts
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type {
+    fetchLyricsForTrackUri as FetchLyricsForTrackUri,
+    clearLyricsCache as ClearLyricsCache
+} from '../src/utils/lyricsFetcher';
+
+const trackId = 'spotify-track-cache-test';
+const trackUri = `spotify:track:${trackId}`;
+
+(globalThis as any).window = {
+    fetch: async () => {
+        throw new Error('Spicy Lyrics API should not be fetched when cache has lyrics');
+    }
+};
+
+function installSpicyLyricsCache(content: any): void {
+    (globalThis as any).caches = {
+        open: async (name: string) => {
+            assert.equal(name, 'SpicyLyrics_LyricsStore');
+            return {
+                match: async (key: string) => {
+                    assert.equal(key, `/${trackId}`);
+                    return {
+                        json: async () => ({
+                            ExpiresAt: Date.now() + 60_000,
+                            CacheVersion: 12,
+                            Content: content
+                        })
+                    };
+                }
+            };
+        }
+    };
+}
+
+const {
+    fetchLyricsForTrackUri,
+    clearLyricsCache
+} = require('../src/utils/lyricsFetcher') as {
+    fetchLyricsForTrackUri: typeof FetchLyricsForTrackUri;
+    clearLyricsCache: typeof ClearLyricsCache;
+};
+
+test('reads original lyrics from Spicy Lyrics Cache API when query capture is unavailable', async () => {
+    clearLyricsCache();
+    installSpicyLyricsCache({
+        id: trackId,
+        Type: 'Syllable',
+        LanguageISO2: 'ja',
+        Content: [
+            {
+                Type: 'Vocal',
+                Lead: {
+                    StartTime: 0,
+                    EndTime: 1000,
+                    Syllables: [
+                        {
+                            Text: '\u541b',
+                            RomanizedText: 'kimi',
+                            StartTime: 0,
+                            EndTime: 300,
+                            IsPartOfWord: false
+                        },
+                        {
+                            Text: '\u306f',
+                            RomanizedText: 'wa',
+                            StartTime: 300,
+                            EndTime: 500,
+                            IsPartOfWord: false
+                        },
+                        {
+                            Text: '\u4e16\u754c',
+                            RomanizedText: 'sekai',
+                            StartTime: 500,
+                            EndTime: 1000,
+                            IsPartOfWord: false
+                        }
+                    ]
+                }
+            }
+        ]
+    });
+
+    const result = await fetchLyricsForTrackUri(trackUri);
+
+    assert.deepEqual(result?.lines, ['\u541b \u306f \u4e16\u754c']);
+    assert.equal(result?.lineData[0]?.romanizedText, 'kimi wa sekai');
+    assert.equal(result?.language, 'ja');
+});

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -1,0 +1,34 @@
+import { mkdtempSync, readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import esbuild from 'esbuild';
+
+const outDir = mkdtempSync(path.join(tmpdir(), 'slt-tests-'));
+const entryPoints = readdirSync('tests')
+    .filter(file => file.endsWith('.test.ts'))
+    .map(file => path.join('tests', file));
+
+await esbuild.build({
+    entryPoints,
+    outdir: outDir,
+    bundle: true,
+    platform: 'node',
+    target: 'node20',
+    format: 'cjs',
+    logLevel: 'silent',
+    define: {
+        __VERSION__: JSON.stringify('test'),
+        __DEV__: JSON.stringify(true)
+    }
+});
+
+const builtTests = readdirSync(outDir)
+    .filter(file => file.endsWith('.js') || file.endsWith('.cjs'))
+    .map(file => path.join(outDir, file));
+
+const result = spawnSync(process.execPath, ['--test', ...builtTests], {
+    stdio: 'inherit'
+});
+
+process.exit(result.status ?? 1);

--- a/tests/settings-menu.test.ts
+++ b/tests/settings-menu.test.ts
@@ -1,0 +1,179 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+type RegisteredMenuItem = {
+    label: string;
+    callback: () => unknown | Promise<unknown>;
+};
+
+const storageMap = new Map<string, string>();
+
+(globalThis as any).localStorage = {
+    getItem: (key: string) => storageMap.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+        storageMap.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+        storageMap.delete(key);
+    },
+    key: (index: number) => Array.from(storageMap.keys())[index] ?? null,
+    get length() {
+        return storageMap.size;
+    }
+};
+
+(globalThis as any).document = {
+    body: {},
+    querySelector: () => null,
+    getElementById: () => null
+};
+
+(globalThis as any).window = {
+    location: {
+        pathname: '/',
+        href: 'https://xpui.app.spotify.com/'
+    }
+};
+
+(globalThis as any).MutationObserver = class {
+    constructor(_callback: MutationCallback) {}
+    observe(): void {}
+    disconnect(): void {}
+};
+
+function installSpicetifyMock(registered: RegisteredMenuItem[], notifications: string[] = []): void {
+    (globalThis as any).Spicetify = {
+        Platform: {
+            History: {
+                location: { pathname: '/' },
+                listen: () => {}
+            }
+        },
+        Menu: {
+            Item: class {
+                constructor(
+                    private readonly label: string,
+                    _isEnabled: boolean,
+                    private readonly callback: () => unknown | Promise<unknown>
+                ) {}
+
+                register(): void {
+                    registered.push({
+                        label: this.label,
+                        callback: this.callback
+                    });
+                }
+            }
+        },
+        showNotification: (message: string) => {
+            notifications.push(message);
+        }
+    };
+}
+
+function getMenuItem(registered: RegisteredMenuItem[], label: string): RegisteredMenuItem {
+    const item = registered.find(entry => entry.label === label);
+    assert.ok(item, `Missing menu item: ${label}`);
+    return item;
+}
+
+test('settings menu registers quick actions for clearing translation and Spicy Lyrics caches', async () => {
+    storageMap.clear();
+    const registered: RegisteredMenuItem[] = [];
+    const notifications: string[] = [];
+    installSpicetifyMock(registered, notifications);
+
+    let deletedCacheName = '';
+    (globalThis as any).caches = {
+        delete: async (cacheName: string) => {
+            deletedCacheName = cacheName;
+            return true;
+        }
+    };
+
+    const { registerSettings } = require('../src/utils/settings') as { registerSettings: () => Promise<void> };
+    await registerSettings();
+
+    assert.deepEqual(registered.map(item => item.label), [
+        'Spicy Lyric Translator Settings',
+        'Clear Spicy Lyrics Cache',
+        'Clear SLT Translation Cache'
+    ]);
+
+    storageMap.set('spicy-lyric-translator:translation-cache', '{"vi:hello":{"translation":"xin chao","timestamp":1}}');
+    storageMap.set('slt-track-cache:spotify:track:abc:vi', '{"lines":["xin chao"],"timestamp":1}');
+    storageMap.set('slt-track-cache-index', '{"trackUris":["spotify:track:abc:vi"]}');
+
+    await getMenuItem(registered, 'Clear SLT Translation Cache').callback();
+    assert.equal(storageMap.has('spicy-lyric-translator:translation-cache'), false);
+    assert.equal(storageMap.has('slt-track-cache:spotify:track:abc:vi'), false);
+    assert.equal(storageMap.has('slt-track-cache-index'), false);
+
+    await getMenuItem(registered, 'Clear Spicy Lyrics Cache').callback();
+    assert.equal(deletedCacheName, 'SpicyLyrics_LyricsStore');
+    assert.deepEqual(notifications, [
+        'All cached translations deleted!',
+        'Spicy Lyrics cached lyrics deleted!'
+    ]);
+});
+
+test('settings modal exposes cache repair actions for the translate button right-click flow', async () => {
+    storageMap.clear();
+    const notifications: string[] = [];
+    installSpicetifyMock([], notifications);
+
+    let deletedCacheName = '';
+    (globalThis as any).caches = {
+        delete: async (cacheName: string) => {
+            deletedCacheName = cacheName;
+            return true;
+        }
+    };
+
+    const settings = require('../src/utils/settings') as {
+        renderModalCacheActionsMarkup: () => string;
+        bindModalCacheActions: (container: ParentNode) => void;
+    };
+
+    const markup = settings.renderModalCacheActionsMarkup();
+    assert.match(markup, /id="slt-clear-spicy-lyrics-cache"/);
+    assert.match(markup, /Clear Spicy Lyrics Cache/);
+    assert.match(markup, /id="slt-clear-translation-cache"/);
+    assert.match(markup, /Clear All Cached Translations/);
+
+    const handlers = new Map<string, EventListenerOrEventListenerObject>();
+    const fakeContainer = {
+        querySelector: (selector: string) => {
+            if (selector !== '#slt-clear-spicy-lyrics-cache' && selector !== '#slt-clear-translation-cache') {
+                return null;
+            }
+            return {
+                addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+                    handlers.set(selector, listener);
+                }
+            };
+        }
+    } as unknown as ParentNode;
+
+    settings.bindModalCacheActions(fakeContainer);
+
+    storageMap.set('spicy-lyric-translator:translation-cache', '{"vi:hello":{"translation":"xin chao","timestamp":1}}');
+    storageMap.set('slt-track-cache:spotify:track:def:vi', '{"lines":["xin chao"],"timestamp":1}');
+    storageMap.set('slt-track-cache-index', '{"trackUris":["spotify:track:def:vi"]}');
+
+    const clearTranslations = handlers.get('#slt-clear-translation-cache') as EventListener;
+    clearTranslations(new Event('click'));
+
+    assert.equal(storageMap.has('spicy-lyric-translator:translation-cache'), false);
+    assert.equal(storageMap.has('slt-track-cache:spotify:track:def:vi'), false);
+    assert.equal(storageMap.has('slt-track-cache-index'), false);
+
+    const clearSpicyLyrics = handlers.get('#slt-clear-spicy-lyrics-cache') as EventListener;
+    await clearSpicyLyrics(new Event('click'));
+
+    assert.equal(deletedCacheName, 'SpicyLyrics_LyricsStore');
+    assert.deepEqual(notifications, [
+        'All cached translations deleted!',
+        'Spicy Lyrics cached lyrics deleted!'
+    ]);
+});

--- a/tests/translator-providers.test.ts
+++ b/tests/translator-providers.test.ts
@@ -1,0 +1,302 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { setPreferredApi as SetPreferredApi, translateText as TranslateText } from '../src/utils/translator';
+
+type FetchCall = {
+    url: string;
+    init?: RequestInit;
+};
+
+const storageMap = new Map<string, string>();
+
+(globalThis as any).localStorage = {
+    getItem: (key: string) => storageMap.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+        storageMap.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+        storageMap.delete(key);
+    },
+    key: (index: number) => Array.from(storageMap.keys())[index] ?? null,
+    get length() {
+        return storageMap.size;
+    }
+};
+
+Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { onLine: true }
+});
+
+const { setPreferredApi, translateText } = require('../src/utils/translator') as {
+    setPreferredApi: typeof SetPreferredApi;
+    translateText: typeof TranslateText;
+};
+
+function resetState(): void {
+    storageMap.clear();
+    delete (globalThis as any).Spicetify;
+    setPreferredApi('google');
+}
+
+function jsonResponse(data: unknown, ok = true, status = 200): Response {
+    return {
+        ok,
+        status,
+        json: async () => data,
+        text: async () => JSON.stringify(data)
+    } as Response;
+}
+
+test('LibreTranslate sends a real POST request using form data to avoid JSON preflight', async () => {
+    resetState();
+    setPreferredApi('libretranslate');
+
+    const calls: FetchCall[] = [];
+    (globalThis as any).fetch = async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return jsonResponse({ translatedText: 'Xin chao' });
+    };
+
+    const result = await translateText('\u3053\u3093\u306b\u3061\u306f', 'vi', 'ja');
+
+    assert.equal(result.translatedText, 'Xin chao');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'https://libretranslate.de/translate');
+    assert.equal(calls[0].init?.method, 'POST');
+    assert.ok(calls[0].init?.body instanceof URLSearchParams);
+    assert.equal((calls[0].init?.body as URLSearchParams).get('q'), '\u3053\u3093\u306b\u3061\u306f');
+    assert.equal((calls[0].init?.body as URLSearchParams).get('target'), 'vi');
+    assert.deepEqual(calls[0].init?.headers, undefined);
+});
+
+test('LibreTranslate batch uses one Cosmos request with newline text and does not fall back when lines parse', async () => {
+    resetState();
+    setPreferredApi('libretranslate');
+
+    const sourceLines = [
+        '\u4eca\u306f\u6614 \u8ab0\u3082\u304c\u77e5\u308b\u7269\u8a9e',
+        '\u304b\u306e\u6709\u540d\u306a\u304b\u3050\u3084\u59eb\u306f\u3053\u3046\u8a00\u3063\u305f',
+        '\u305d\u3093\u306a\u7d50\u672b\u3061\u3063\u3068\u3082\u671b\u3093\u3067\u306a\u3044\u3057'
+    ];
+    const translatedLines = [
+        'Ngày xửa ngày xưa, câu chuyện ai cũng biết',
+        'Nàng Kaguya nổi tiếng ấy đã nói thế này',
+        'Em chẳng hề mong một kết cục như vậy'
+    ];
+
+    const fetchCalls: FetchCall[] = [];
+    (globalThis as any).fetch = async (url: string, init?: RequestInit) => {
+        fetchCalls.push({ url, init });
+        throw new Error('direct fetch should not be used when CosmosAsync is available');
+    };
+
+    const cosmosCalls: Array<{ url: string; body?: any; headers?: Record<string, string> }> = [];
+    (globalThis as any).Spicetify = {
+        CosmosAsync: {
+            post: async (url: string, body?: any, headers?: Record<string, string>) => {
+                cosmosCalls.push({ url, body, headers });
+                return { translatedText: translatedLines.join('\n') };
+            }
+        }
+    };
+
+    const { translateLyrics } = require('../src/utils/translator') as { translateLyrics: (lines: string[], targetLang: string) => Promise<any[]> };
+    const result = await translateLyrics(sourceLines, 'vi');
+
+    assert.equal(fetchCalls.length, 0);
+    assert.equal(cosmosCalls.length, 1);
+    assert.equal(cosmosCalls[0].url, 'https://libretranslate.de/translate');
+    assert.equal(cosmosCalls[0].body.q, sourceLines.join('\n'));
+    assert.equal(cosmosCalls[0].body.target, 'vi');
+    assert.deepEqual(cosmosCalls[0].headers, { 'Content-Type': 'application/json' });
+    assert.deepEqual(result.map(item => item.translatedText), translatedLines);
+});
+
+test('LibreTranslate does not send internal batch markers to Google fallback', async () => {
+    resetState();
+    setPreferredApi('libretranslate');
+
+    const calls: FetchCall[] = [];
+    (globalThis as any).fetch = async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return jsonResponse({ message: 'temporary failure' }, false, 500);
+    };
+
+    const { translateLyrics } = require('../src/utils/translator') as { translateLyrics: (lines: string[], targetLang: string) => Promise<any[]> };
+    await translateLyrics([
+        '\u4eca\u306f\u6614 \u8ab0\u3082\u304c\u77e5\u308b\u7269\u8a9e',
+        '\u304b\u306e\u6709\u540d\u306a\u304b\u3050\u3084\u59eb\u306f\u3053\u3046\u8a00\u3063\u305f'
+    ], 'vi');
+
+    assert.equal(
+        calls.some(call => call.url.includes('translate.googleapis.com') && call.url.includes('SLT_BATCH')),
+        false
+    );
+});
+
+test('DeepL sends header-based auth instead of deprecated auth_key request body auth', async () => {
+    resetState();
+    setPreferredApi('deepl', undefined, { deeplApiKey: 'test-key:fx' });
+
+    const calls: FetchCall[] = [];
+    (globalThis as any).fetch = async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return jsonResponse({
+            translations: [
+                {
+                    text: 'Xin chao',
+                    detected_source_language: 'JA'
+                }
+            ]
+        });
+    };
+
+    const result = await translateText('\u3053\u3093\u306b\u3061\u306f', 'vi', 'ja');
+
+    assert.equal(result.translatedText, 'Xin chao');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'https://cors-proxy.spicetify.app/https://api-free.deepl.com/v2/translate');
+    assert.equal(calls[0].init?.method, 'POST');
+    assert.deepEqual(calls[0].init?.headers, {
+        'Authorization': 'DeepL-Auth-Key test-key:fx',
+        'Content-Type': 'application/json'
+    });
+
+    const body = JSON.parse(String(calls[0].init?.body));
+    assert.deepEqual(body, {
+        text: ['\u3053\u3093\u306b\u3061\u306f'],
+        target_lang: 'VI'
+    });
+    assert.equal(Object.prototype.hasOwnProperty.call(body, 'auth_key'), false);
+});
+
+test('DeepL 403 stops after one batch request instead of retrying marker and per-line fallbacks', async () => {
+    resetState();
+    setPreferredApi('deepl', undefined, { deeplApiKey: 'bad-key:fx' });
+
+    const calls: FetchCall[] = [];
+    (globalThis as any).fetch = async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return jsonResponse({ message: 'Forbidden' }, false, 403);
+    };
+
+    const { translateLyrics } = require('../src/utils/translator') as { translateLyrics: (lines: string[], targetLang: string) => Promise<any[]> };
+    const result = await translateLyrics(['\u5e7e\u5343\u306e\u6642\u3092\u5de1\u3063\u3066 \u4eca', '\u50d5\u3089\u51fa\u4f1a\u3048\u305f \u306e'], 'vi');
+
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].init?.headers, {
+        'Authorization': 'DeepL-Auth-Key bad-key:fx',
+        'Content-Type': 'application/json'
+    });
+    assert.deepEqual(JSON.parse(String(calls[0].init?.body)), {
+        text: ['\u5e7e\u5343\u306e\u6642\u3092\u5de1\u3063\u3066 \u4eca', '\u50d5\u3089\u51fa\u4f1a\u3048\u305f \u306e'],
+        target_lang: 'VI'
+    });
+    assert.deepEqual(result.map(item => item.translatedText), ['\u5e7e\u5343\u306e\u6642\u3092\u5de1\u3063\u3066 \u4eca', '\u50d5\u3089\u51fa\u4f1a\u3048\u305f \u306e']);
+});
+
+test('Gemini uses the configured model in the generateContent endpoint', async () => {
+    resetState();
+    setPreferredApi('gemini', undefined, {
+        geminiApiKey: 'gemini-key',
+        geminiModel: 'gemini-2.5-flash'
+    } as any);
+
+    const calls: FetchCall[] = [];
+    (globalThis as any).fetch = async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return jsonResponse({
+            candidates: [
+                {
+                    content: {
+                        parts: [{ text: 'Xin chao' }]
+                    }
+                }
+            ]
+        });
+    };
+
+    const result = await translateText('\u3053\u3093\u306b\u3061\u306f', 'vi', 'ja');
+
+    assert.equal(result.translatedText, 'Xin chao');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent');
+});
+
+test('Gemini uses the configured temperature in generationConfig', async () => {
+    resetState();
+    setPreferredApi('gemini', undefined, {
+        geminiApiKey: 'gemini-key',
+        geminiTemperature: '0.8'
+    } as any);
+
+    const calls: FetchCall[] = [];
+    (globalThis as any).fetch = async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return jsonResponse({
+            candidates: [
+                {
+                    content: {
+                        parts: [{ text: 'Xin chao' }]
+                    }
+                }
+            ]
+        });
+    };
+
+    await translateText('\u3053\u3093\u306b\u3061\u306f', 'vi', 'ja');
+
+    const body = JSON.parse(String(calls[0].init?.body));
+    assert.equal(body.generationConfig.temperature, 0.8);
+});
+
+test('Gemini accepts a complete code-fenced batch response without sending chunked follow-up requests', async () => {
+    resetState();
+    setPreferredApi('gemini', undefined, {
+        geminiApiKey: 'gemini-key',
+        geminiModel: 'gemini-3.1-flash-lite',
+        geminiTemperature: '0.6'
+    } as any);
+
+    const sourceLines = [
+        '\u4eca\u306f\u6614 \u8ab0\u3082\u304c\u77e5\u308b\u7269\u8a9e',
+        '\u304b\u306e\u6709\u540d\u306a\u304b\u3050\u3084\u59eb\u306f\u3053\u3046\u8a00\u3063\u305f',
+        '\u305d\u3093\u306a\u7d50\u672b\u3061\u3063\u3068\u3082\u671b\u3093\u3067\u306a\u3044\u3057',
+        '\u904b\u547d\u3060\u304b\u3089\u3063\u3066\u30ad\u30df\u305d\u308c\u3067\u9817\u304f\u306e\uff1f',
+        '\u8ab0\u304b\u306e\u66f8\u3044\u305f\u304a\u8a71\u3058\u3083\u306a\u3044',
+        '\u3053\u3053\u306b\u3044\u308b\u30ad\u30df\u3068\u79c1',
+        '\u61d0\u304b\u3057\u3044\u3088\u3046\u306a',
+        '\u521d\u3081\u3066\u306e\u3088\u3046\u306a'
+    ];
+    const translatedLines = [
+        'Ngày xửa ngày xưa, câu chuyện ai cũng biết',
+        'Nàng Kaguya nổi tiếng ấy đã nói thế này',
+        'Em chẳng hề mong một kết cục như vậy',
+        'Chỉ vì là số phận, anh sẽ gật đầu sao?',
+        'Đây không phải câu chuyện do ai đó viết',
+        'Mà là anh và em đang ở nơi này',
+        'Như thể thật thân quen',
+        'Như thể lần đầu gặp gỡ'
+    ];
+
+    const calls: FetchCall[] = [];
+    (globalThis as any).fetch = async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return jsonResponse({
+            candidates: [
+                {
+                    content: {
+                        parts: [{ text: ['```text', ...translatedLines, '```'].join('\n') }]
+                    }
+                }
+            ]
+        });
+    };
+
+    const { translateLyrics } = require('../src/utils/translator') as { translateLyrics: (lines: string[], targetLang: string) => Promise<any[]> };
+    const result = await translateLyrics(sourceLines, 'vi');
+
+    assert.equal(calls.length, 1);
+    assert.deepEqual(result.map(item => item.translatedText), translatedLines);
+});

--- a/tests/vocabulary-mode.test.ts
+++ b/tests/vocabulary-mode.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { buildVocabularyPairs as BuildVocabularyPairs } from '../src/utils/translationOverlay';
+
+(globalThis as any).localStorage = {
+    length: 0,
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+    key: () => null
+};
+
+const { buildVocabularyPairs } = require('../src/utils/translationOverlay') as {
+    buildVocabularyPairs: typeof BuildVocabularyPairs;
+};
+
+test('vocabulary mode aligns common Japanese phrase chunks to Vietnamese translation order', () => {
+    const pairs = buildVocabularyPairs(
+        '\u3053\u306e\u307e\u307e\u63fa\u3055\u3076\u3089\u308c\u3066\u3044\u305f\u3044 \u306a',
+        'Mu\u1ed1n m\u00e3i \u0111ung \u0111\u01b0a th\u1ebf n\u00e0y th\u00f4i'
+    );
+
+    assert.deepEqual(
+        pairs.map(pair => [pair.translated, pair.original]),
+        [
+            ['Mu\u1ed1n m\u00e3i \u0111ung \u0111\u01b0a', '\u63fa\u3055\u3076\u3089\u308c\u3066\u3044\u305f\u3044'],
+            ['th\u1ebf n\u00e0y', '\u3053\u306e\u307e\u307e'],
+            ['th\u00f4i', '\u306a']
+        ]
+    );
+    assert.ok(pairs.every(pair => pair.confidence !== 'low'));
+});
+
+test('vocabulary mode falls back to one phrase pair when Japanese alignment is uncertain', () => {
+    const pairs = buildVocabularyPairs(
+        '\u661f\u306e\u964d\u308b\u97f3\u304c\u805e\u3053\u3048\u308b\u3067\u3057\u3087\u3046',
+        'Em c\u00f3 nghe th\u1ea5y \u00e2m thanh nh\u1eefng v\u00ec sao r\u01a1i kh\u00f4ng'
+    );
+
+    assert.deepEqual(pairs, [
+        {
+            original: '\u661f\u306e\u964d\u308b\u97f3\u304c\u805e\u3053\u3048\u308b\u3067\u3057\u3087\u3046',
+            translated: 'Em c\u00f3 nghe th\u1ea5y \u00e2m thanh nh\u1eefng v\u00ec sao r\u01a1i kh\u00f4ng',
+            confidence: 'low',
+            sourceIndex: 0,
+            translatedStart: 0
+        }
+    ]);
+});


### PR DESCRIPTION
This PR fixes romanization mode translation source handling and improves Vocabulary / Learning Mode.

Changes:
- Use original Spicy Lyrics source text instead of romanized DOM text when romanization is enabled.
- Read original lyrics from SpicyLyrics_LyricsStore when /query is not fired again.
- Add cache repair actions for Spicy Lyrics lyrics and SLT translations.
- Fix provider request handling for DeepL, LibreTranslate, Gemini, and custom endpoints.
- Add Gemini custom model and temperature settings.
- Improve Vocabulary / Learning Mode with phrase-aware Japanese alignment and low-confidence fallback.
- Add regression tests for source selection, provider behavior, settings actions, cache fallback, and vocabulary alignment.